### PR TITLE
[MINOR] Build as a CommonJS Module

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,16 +13,6 @@ Install it using your preferred package manager:
 - `yarn add dualsense-ts`
 - `npm add dualsense-ts`
 
-#### Heads up!
-
-`dualsense-ts` is an ES module (esm), and uses ES import resolution. To use this module in Node.js, you'll need to take these steps:
-
-1. Use Node.js v16+, or the `--experimental-modules` flag while invoking `node`
-2. Use the `--experimental-specifier-resolution=node` flag while invoking `node`
-3. Set `"type": "module"` in your `package.json`
-
-(if you're familiar with a way to make the package more backwards-compatible, please help me out by opening a PR!)
-
 ### Connecting
 
 By default, `dualsense-ts` will try to connect to the first Dualsense controller it finds.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "nsfm"
   ],
   "license": "GPL-3.0",
-  "type": "module",
   "private": false,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "strict": true,
     "alwaysStrict": true,
-    "module": "ESNext",
+    "module": "commonjs",
     "target": "ES2020",
     "moduleResolution": "Node",
     "lib": ["ES2021", "DOM"],


### PR DESCRIPTION
Currently, when attempting to use the package in node with `require()` syntax, the following error is thrown:

```
Error [ERR_REQUIRE_ESM]: require() of ES Module dist/index.js from index.js not supported.
dist/index.js is treated as an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which declares all .js files in that package scope as ES modules.
Instead rename dist/index.js to end in .cjs, change the requiring code to use dynamic import() which is available in all CommonJS modules, or change "type": "module" to "type": "commonjs" in package.json to treat all .js files as CommonJS (using .mjs for all ES modules instead).
```

For backwards compatibility, informing TSC to compile to CommonJS, in conjunction with [ES Module Interop](https://www.typescriptlang.org/tsconfig#esModuleInterop), ESModule behavior is preserved while allowing support for `require()` statements.

By removing the `type` field in `package.json`, the loaded module will be [treated as CommonJS](https://nodejs.org/api/packages.html#type) by default:
> If the nearest parent package.json lacks a "type" field, or contains "type": "commonjs", .js files are treated as [CommonJS](https://nodejs.org/api/modules.html). If the volume root is reached and no package.json is found, .js files are treated as [CommonJS](https://nodejs.org/api/modules.html).