### PR TITLE
[MINOR] Gyroscope/Accelerometer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,25 @@ for await (const { pressure } of controller.left.trigger) {
 }
 ```
 
-### Rumble Support
+### Other Supported Features
+
+#### Motion Control
+
+```typescript
+controller.gyroscope.on("change", ({ x, y, z }) => {
+  console.log(`Gyroscope: \n\t${x}\n\t${y}\n\t${z}`)
+}
+
+controller.accelerometer.on("change", ({ x, y, z }) => {
+  console.log(`Accelerometer: \n\t${x}\n\t${y}\n\t${z}`)
+}
+
+controller.accelerometer.z.on("change", ({ force }) => {
+  if (force > 0.3) console.log('Controller moving')
+})
+```
+
+#### Rumble
 
 Only supported in node.js over USB at this time.
 

--- a/src/dualsense.ts
+++ b/src/dualsense.ts
@@ -8,6 +8,8 @@ import {
   Touchpad,
   Gyroscope,
   GyroscopeParams,
+  Accelerometer,
+  AccelerometerParams,
 } from "./elements";
 import { Input, InputSet, InputParams } from "./input";
 import {
@@ -48,6 +50,8 @@ export interface DualsenseParams extends InputParams {
   touchpad?: InputParams;
   /** Settings for the gyroscope */
   gyro?: GyroscopeParams;
+  /** Settings for the accelerometer */
+  accel?: AccelerometerParams;
 }
 
 /** Represents a Dualsense controller */
@@ -78,8 +82,10 @@ export class Dualsense extends Input<Dualsense> {
   public readonly right: Unisense;
   /** The touchpad; works like a pair of analog sticks */
   public readonly touchpad: Touchpad;
-  /** Tracks the controller's rate of rotation */
+  /** Tracks the controller's angular velocity */
   public readonly gyro: Gyroscope;
+  /** Tracks the controller's linear acceleration */
+  public readonly accelerometer: Accelerometer;
 
   /** Represents the underlying HID device. Provides input events */
   public readonly hid: DualsenseHID;
@@ -166,6 +172,12 @@ export class Dualsense extends Input<Dualsense> {
       name: "Gyroscope",
       threshold: 0.01,
       ...(params.gyro ?? {}),
+    });
+    this.accelerometer = new Accelerometer({
+      icon: "",
+      name: "Accelerometer",
+      threshold: 0.01,
+      ...(params.accel ?? {}),
     });
 
     this.connection[InputSet](false);
@@ -257,5 +269,8 @@ export class Dualsense extends Input<Dualsense> {
     this.gyro.x[InputSet](state[InputId.GyroX]);
     this.gyro.y[InputSet](state[InputId.GyroY]);
     this.gyro.z[InputSet](state[InputId.GyroZ]);
+    this.accelerometer.x[InputSet](state[InputId.AccelX]);
+    this.accelerometer.y[InputSet](state[InputId.AccelY]);
+    this.accelerometer.z[InputSet](state[InputId.AccelZ]);
   }
 }

--- a/src/dualsense.ts
+++ b/src/dualsense.ts
@@ -49,9 +49,9 @@ export interface DualsenseParams extends InputParams {
   /** Settings for the touchpad inputs */
   touchpad?: InputParams;
   /** Settings for the gyroscope */
-  gyro?: GyroscopeParams;
+  gyroscope?: GyroscopeParams;
   /** Settings for the accelerometer */
-  accel?: AccelerometerParams;
+  accelerometer?: AccelerometerParams;
 }
 
 /** Represents a Dualsense controller */
@@ -83,7 +83,7 @@ export class Dualsense extends Input<Dualsense> {
   /** The touchpad; works like a pair of analog sticks */
   public readonly touchpad: Touchpad;
   /** Tracks the controller's angular velocity */
-  public readonly gyro: Gyroscope;
+  public readonly gyroscope: Gyroscope;
   /** Tracks the controller's linear acceleration */
   public readonly accelerometer: Accelerometer;
 
@@ -167,17 +167,17 @@ export class Dualsense extends Input<Dualsense> {
       name: "Connected",
       ...(params.square ?? {}),
     });
-    this.gyro = new Gyroscope({
+    this.gyroscope = new Gyroscope({
       icon: "∞",
       name: "Gyroscope",
       threshold: 0.01,
-      ...(params.gyro ?? {}),
+      ...(params.gyroscope ?? {}),
     });
     this.accelerometer = new Accelerometer({
-      icon: "",
+      icon: "⤲",
       name: "Accelerometer",
       threshold: 0.01,
-      ...(params.accel ?? {}),
+      ...(params.accelerometer ?? {}),
     });
 
     this.connection[InputSet](false);
@@ -266,9 +266,9 @@ export class Dualsense extends Input<Dualsense> {
     this.right.trigger[InputSet](state[InputId.RightTrigger]);
     this.right.trigger.button[InputSet](state[InputId.RightTriggerButton]);
 
-    this.gyro.x[InputSet](state[InputId.GyroX]);
-    this.gyro.y[InputSet](state[InputId.GyroY]);
-    this.gyro.z[InputSet](state[InputId.GyroZ]);
+    this.gyroscope.x[InputSet](state[InputId.GyroX]);
+    this.gyroscope.y[InputSet](state[InputId.GyroY]);
+    this.gyroscope.z[InputSet](state[InputId.GyroZ]);
     this.accelerometer.x[InputSet](state[InputId.AccelX]);
     this.accelerometer.y[InputSet](state[InputId.AccelY]);
     this.accelerometer.z[InputSet](state[InputId.AccelZ]);

--- a/src/elements/accelerometer.ts
+++ b/src/elements/accelerometer.ts
@@ -1,7 +1,48 @@
-import { Input } from "../input";
+import { Input, InputParams } from "../input";
+import { Axis, AxisParams } from "./axis";
 
-/** Not yet implemented */
-export class Accelerometer extends Input<boolean> {
-  public readonly state: boolean = false;
+export interface AccelerometerParams extends InputParams {
+  /** Configuration for the input's x axis */
+  x?: AxisParams;
+
+  /** Configuration for the input's y axis */
+  y?: AxisParams;
+
+  /** Configuration for the input's z axis */
+  z?: AxisParams;
+}
+
+/** Tracks the linear acceleration of the controller. */
+export class Accelerometer extends Input<Accelerometer> {
+  public readonly state: this = this;
+
+  public readonly x: Axis;
+  public readonly y: Axis;
+  public readonly z: Axis;
+
+  constructor(params?: AccelerometerParams) {
+    super(params);
+    const { x, y, z } = params ?? {};
+
+    this.x = new Axis({
+      icon: "AX",
+      name: "X",
+      ...params,
+      ...x,
+    });
+    this.y = new Axis({
+      icon: "AY",
+      name: "Y",
+      ...params,
+      ...y,
+    });
+    this.z = new Axis({
+      icon: "AZ",
+      name: "Z",
+      ...params,
+      ...z,
+    });
+  }
+
   public readonly active = false;
 }

--- a/src/elements/gyroscope.ts
+++ b/src/elements/gyroscope.ts
@@ -1,7 +1,48 @@
-import { Input } from "../input";
+import { Input, InputParams } from "../input";
+import { Axis, AxisParams } from "./axis";
 
-/** Not yet implemented */
-export class Gyroscope extends Input<boolean> {
-  public readonly state: boolean = false;
+export interface GyroscopeParams extends InputParams {
+  /** Configuration for the input's x axis */
+  x?: AxisParams;
+
+  /** Configuration for the input's y axis */
+  y?: AxisParams;
+
+  /** Configuration for the input's z axis */
+  z?: AxisParams;
+}
+
+/** Tracks the rotation of the controller. */
+export class Gyroscope extends Input<Gyroscope> {
+  public readonly state: this = this;
+
+  public readonly x: Axis;
+  public readonly y: Axis;
+  public readonly z: Axis;
+
+  constructor(params?: GyroscopeParams) {
+    super(params);
+    const { x, y, z } = params ?? {};
+
+    this.x = new Axis({
+      icon: "GX",
+      name: "X",
+      ...params,
+      ...x,
+    });
+    this.y = new Axis({
+      icon: "GY",
+      name: "Y",
+      ...params,
+      ...y,
+    });
+    this.z = new Axis({
+      icon: "GZ",
+      name: "Z",
+      ...params,
+      ...z,
+    });
+  }
+
   public readonly active = false;
 }

--- a/src/elements/gyroscope.ts
+++ b/src/elements/gyroscope.ts
@@ -12,7 +12,7 @@ export interface GyroscopeParams extends InputParams {
   z?: AxisParams;
 }
 
-/** Tracks the rotation of the controller. */
+/** Tracks the angular velocity of the controller. */
 export class Gyroscope extends Input<Gyroscope> {
   public readonly state: this = this;
 

--- a/src/hid/dualsense_hid.ts
+++ b/src/hid/dualsense_hid.ts
@@ -1,5 +1,9 @@
 import { CommandScopeA, CommandScopeB, TriggerMode, PlayerID } from "./command";
-import { HIDProvider, DualsenseHIDState, InputId } from "./hid_provider";
+import {
+  HIDProvider,
+  DualsenseHIDState,
+  DefaultDualsenseHIDState,
+} from "./hid_provider";
 
 export type HIDCallback = (state: DualsenseHIDState) => void;
 export type ErrorCallback = (error: Error) => void;
@@ -26,51 +30,12 @@ export class DualsenseHID {
   /** Queue of pending HID commands */
   private pendingCommands: CommandEvent[] = [];
   /** Most recent HID state of the device */
-  public state: DualsenseHIDState = {
-    [InputId.LeftAnalogX]: 0,
-    [InputId.LeftAnalogY]: 0,
-    [InputId.RightAnalogX]: 0,
-    [InputId.RightAnalogY]: 0,
-    [InputId.LeftTrigger]: 0,
-    [InputId.RightTrigger]: 0,
-    [InputId.Triangle]: false,
-    [InputId.Circle]: false,
-    [InputId.Cross]: false,
-    [InputId.Square]: false,
-    [InputId.Dpad]: 0,
-    [InputId.Up]: false,
-    [InputId.Down]: false,
-    [InputId.Left]: false,
-    [InputId.Right]: false,
-    [InputId.RightAnalogButton]: false,
-    [InputId.LeftAnalogButton]: false,
-    [InputId.Options]: false,
-    [InputId.Create]: false,
-    [InputId.RightTriggerButton]: false,
-    [InputId.LeftTriggerButton]: false,
-    [InputId.RightBumper]: false,
-    [InputId.LeftBumper]: false,
-    [InputId.Playstation]: false,
-    [InputId.TouchButton]: false,
-    [InputId.Mute]: false,
-    [InputId.Status]: false,
-    [InputId.TouchX0]: 0,
-    [InputId.TouchY0]: 0,
-    [InputId.TouchContact0]: false,
-    [InputId.TouchId0]: 0,
-    [InputId.TouchX1]: 0,
-    [InputId.TouchY1]: 0,
-    [InputId.TouchContact1]: false,
-    [InputId.TouchId1]: 0,
-    [InputId.GyroX]: 0,
-    [InputId.GyroY]: 0,
-    [InputId.GyroZ]: 0,
-    [InputId.AccelX]: 0,
-    [InputId.AccelY]: 0,
-    [InputId.AccelZ]: 0,
-  };
+  public state: DualsenseHIDState = { ...DefaultDualsenseHIDState };
 
-  constructor(readonly provider: HIDProvider, refreshRate: number = 30) {
+  constructor(
+    readonly provider: HIDProvider,
+    refreshRate: number = 30
+  ) {
     provider.onData = this.set.bind(this);
     provider.onError = this.handleError.bind(this);
 

--- a/src/hid/hid_provider.ts
+++ b/src/hid/hid_provider.ts
@@ -4,7 +4,7 @@ import { ByteArray } from "./byte_array";
 
 export * from "../id";
 
-/** Maps a HID input of 0...n to -1...1 */
+/** Maps a HID input of n...n to -1...1 */
 export function mapAxis(value: number, max: number = 255): number {
   return (2 / max) * Math.max(0, Math.min(max, value)) - 1;
 }
@@ -21,7 +21,7 @@ export function mapTrigger(value: number): number {
 export function mapGyroAccel(v0: number, v1: number): number {
   let v = (v1 << 8) | v0;
   if (v > 0x7fff) v -= 0x10000;
-  return v;
+  return mapAxis(v + 0x7fff, 0xffff);
 }
 
 /** Describes an observation of the input state of a Dualsense controller */
@@ -167,15 +167,15 @@ export abstract class HIDProvider {
 
     switch (reportId) {
       case 0x01:
-        return this.wireless ? this.processBluetoothInputReport01(buffer) : this.processUsbInputReport01(buffer);
+        return this.wireless
+          ? this.processBluetoothInputReport01(buffer)
+          : this.processUsbInputReport01(buffer);
       case 0x31:
         return this.processBluetoothInputReport31(buffer);
 
       default:
         this.onError(
-          new Error(
-            `Cannot process report, unexpected report id: ${reportId}`
-          )
+          new Error(`Cannot process report, unexpected report id: ${reportId}`)
         );
         this.disconnect();
         return { ...DefaultDualsenseHIDState };

--- a/src/hid/hid_provider.ts
+++ b/src/hid/hid_provider.ts
@@ -4,7 +4,7 @@ import { ByteArray } from "./byte_array";
 
 export * from "../id";
 
-/** Maps a HID input of n...n to -1...1 */
+/** Maps a HID input of 0...n to -1...1 */
 export function mapAxis(value: number, max: number = 255): number {
   return (2 / max) * Math.max(0, Math.min(max, value)) - 1;
 }

--- a/src/hid/web_hid_provider.ts
+++ b/src/hid/web_hid_provider.ts
@@ -27,21 +27,32 @@ export class WebHIDProvider extends HIDProvider {
    * USB or Bluetooth interface. The protocol is different depending on the connection
    * type so we will try to detect it based on the collection information.
    */
-  detectConnectionType(): void {    
+  detectConnectionType(): void {
     this.wireless = undefined;
     if (!this.device) {
       return;
     }
 
     for (const c of this.device.collections) {
-      if (c.usagePage !== HIDProvider.usagePage || c.usage !== HIDProvider.usage) {
+      if (
+        c.usagePage !== HIDProvider.usagePage ||
+        c.usage !== HIDProvider.usage
+      ) {
         continue;
       }
 
       // Compute the maximum input report byte length and compare against known values.
-      const maxInputReportBytes = (c.inputReports ?? []).reduce((max, report) => {
-        return Math.max(max, (report.items ?? []).reduce((sum, item) => { return sum + (item.reportSize ?? 0) * (item.reportCount ?? 0); }, 0));
-      }, 0);
+      const maxInputReportBytes = (c.inputReports ?? []).reduce(
+        (max, report) => {
+          return Math.max(
+            max,
+            (report.items ?? []).reduce((sum, item) => {
+              return sum + (item.reportSize ?? 0) * (item.reportCount ?? 0);
+            }, 0)
+          );
+        },
+        0
+      );
 
       if (maxInputReportBytes == 504) {
         this.wireless = false;
@@ -88,7 +99,7 @@ export class WebHIDProvider extends HIDProvider {
               vendorId: HIDProvider.vendorId,
               productId: HIDProvider.productId,
               usagePage: HIDProvider.usagePage,
-              usage: HIDProvider.usage
+              usage: HIDProvider.usage,
             },
           ],
         })

--- a/webhid_example/src/App.tsx
+++ b/webhid_example/src/App.tsx
@@ -1,10 +1,13 @@
 import styled from "styled-components";
 
-import { Reticle, ControllerConnection } from "./hud";
+import {
+  Reticle,
+  ControllerConnection,
+  Gyro,
+  Debugger,
+  HUDLayout,
+} from "./hud";
 import { ControllerContext, controller } from "./Controller";
-import { Debugger } from "./hud/Debugger";
-import { HUDLayout } from "./hud/HUDLayout";
-import { Gyro } from "./hud/Gyro";
 
 const AppContainer = styled.div`
   display: flex;

--- a/webhid_example/src/App.tsx
+++ b/webhid_example/src/App.tsx
@@ -4,6 +4,7 @@ import { Reticle, ControllerConnection } from "./hud";
 import { ControllerContext, controller } from "./Controller";
 import { Debugger } from "./hud/Debugger";
 import { HUDLayout } from "./hud/HUDLayout";
+import { Gyro } from "./hud/Gyro";
 
 const AppContainer = styled.div`
   display: flex;
@@ -22,6 +23,7 @@ export const App = () => {
       <AppContainer className="AppContainer">
         <HUDLayout>
           <Reticle />
+          <Gyro />
           <ControllerConnection />
           <Debugger />
         </HUDLayout>

--- a/webhid_example/src/hud/Gyro.tsx
+++ b/webhid_example/src/hud/Gyro.tsx
@@ -5,16 +5,16 @@ import { Illustration, Ellipse, Shape } from "react-zdog";
 import { RenderedElement } from "./RenderedElement";
 import { ControllerContext } from "../Controller";
 
-interface ReticleState {
+interface GyroState {
   opacity: number;
   diameter: number;
   thickness: number;
   zoom: number;
 }
 
-const StyledReticle = styled(RenderedElement)`
-  grid-column: 3;
-  grid-row: 3 / span 2;
+const StyledGyro = styled(RenderedElement)`
+  grid-column: 5;
+  grid-row: 5;
   justify-content: center;
   align-items: center;
   display: flex;
@@ -23,19 +23,17 @@ const StyledReticle = styled(RenderedElement)`
   opacity: 0.7;
 `;
 
-export const Reticle = () => {
+export const Gyro = () => {
   const controller = React.useContext(ControllerContext);
-  const [{ direction, magnitude }, setAnalog] = React.useState(
-    controller.left.analog.vector
-  );
+  const [{ x, y, z }, setGyro] = React.useState({ ...controller.gyro });
   React.useEffect(() => {
-    controller.left.analog.on("change", (analog) => {
-      setAnalog(analog.vector);
+    controller.gyro.on("change", (gyro) => {
+      setGyro({ ...gyro });
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const [state] = React.useState<ReticleState>({
+  const [state] = React.useState<GyroState>({
     opacity: 0.7,
     diameter: 5,
     thickness: 0.25,
@@ -43,32 +41,33 @@ export const Reticle = () => {
   });
 
   return (
-    <StyledReticle
-      className="Reticle"
+    <StyledGyro
+      className="Gyro"
       width={state.diameter * state.zoom * 1.25}
       height={(state.diameter + 1) * state.zoom}
     >
       <Illustration element="svg" zoom={state.zoom}>
         <Shape
           rotate={{
-            y: Math.sin(direction),
-            x: Math.cos(direction),
+            y: x.state * Math.PI * 2,
+            x: y.state * Math.PI * 2,
+            z: z.state * Math.PI * 2,
           }}
           stroke={0}
         >
           <Ellipse
             stroke={state.thickness}
-            diameter={state.diameter}
+            diameter={state.diameter / 3}
+            translate={{ x: state.diameter / 3 }}
             color="orange"
           />
           <Ellipse
             stroke={state.thickness}
             diameter={state.diameter}
             color="blue"
-            translate={{ x: magnitude, y: magnitude, z: -1 }}
           />
         </Shape>
       </Illustration>
-    </StyledReticle>
+    </StyledGyro>
   );
 };

--- a/webhid_example/src/hud/Gyro.tsx
+++ b/webhid_example/src/hud/Gyro.tsx
@@ -25,10 +25,12 @@ const StyledGyro = styled(RenderedElement)`
 
 export const Gyro = () => {
   const controller = React.useContext(ControllerContext);
-  const [{ x, y, z }, setGyro] = React.useState({ ...controller.gyro });
+  const [{ x, y, z }, setGyro] = React.useState({ ...controller.gyroscope });
+  const [accel, setAccel] = React.useState({ ...controller.accelerometer });
   React.useEffect(() => {
-    controller.gyro.on("change", (gyro) => {
+    controller.gyroscope.on("change", (gyro) => {
       setGyro({ ...gyro });
+      setAccel(accel);
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -58,7 +60,11 @@ export const Gyro = () => {
           <Ellipse
             stroke={state.thickness}
             diameter={state.diameter / 3}
-            translate={{ x: state.diameter / 3 }}
+            translate={{
+              x: accel.x.force * 5,
+              y: accel.y.force * 5,
+              z: accel.z.force * 5,
+            }}
             color="orange"
           />
           <Ellipse

--- a/webhid_example/src/hud/index.tsx
+++ b/webhid_example/src/hud/index.tsx
@@ -4,6 +4,7 @@
 
 export * from "./ControllerConnection";
 export * from "./Debugger";
+export * from "./Gyro";
 export * from "./HUDLayout";
 export * from "./RenderedElement";
 export * from "./Reticle";


### PR DESCRIPTION
Resolves #39 

- Map motion inputs to the main controller interface
- Add motion test component
- Map motion input values from -1 to 1 (technically a breaking change)

@daniloarcidiacono Thanks for fixing the accel/gyro input mapping, I looked at my old PR and I was definitely struggling due to not handling the negative values properly. Wanted to notify you of this change in case you are already using values from the DualsenseHID report, I should have suggested normalizing the range in the previous PR.