### PR TITLE
[MINOR] Support firmware lookup; Improve multi-controller behavior

### DIFF
--- a/LINUX_HID.md
+++ b/LINUX_HID.md
@@ -1,0 +1,85 @@
+# Linux HID and the DualSense
+
+## The Problem
+
+On Linux, the kernel's `hid_playstation` driver claims DualSense controllers and creates gamepad, motion sensor, and touchpad input devices. This has two side effects that affect `dualsense-ts`:
+
+1. **SET_REPORT feature reports are blocked over Bluetooth.** The `hidp` Bluetooth HID transport does not support the `HIDIOCSFEATURE` ioctl, returning `EIO`. This means the test command protocol (Feature Reports `0x80`/`0x81`) cannot be used, and factory info (controller body color, serial number, board revision) is unavailable over Bluetooth when using `node-hid`.
+
+2. **Unwanted input devices are created.** The kernel registers the controller as a gamepad, touchpad, and motion sensor, which can cause the controller to move the mouse cursor or generate unwanted input events on the desktop.
+
+Neither issue affects WebHID in Chrome, which bypasses the kernel's HID driver entirely and communicates with the Bluetooth controller through its own userspace stack.
+
+## What Works Today
+
+| Feature | USB (node-hid) | USB (WebHID) | BT (node-hid, Linux) | BT (WebHID) |
+|---------|---------------|-------------|----------------------|-------------|
+| Input reports (buttons, sticks, etc.) | Yes | Yes | Yes | Yes |
+| Output reports (rumble, LEDs, etc.) | Yes | Yes | Yes | Yes |
+| Firmware info (Feature Report 0x20 read) | Yes | Yes | Yes | Yes |
+| Factory info (Feature Report 0x80 write) | Yes | Yes | **No** | Yes |
+
+## Why It Fails
+
+The data flow for HID feature reports on Linux:
+
+```
+Application (node-hid)
+  -> ioctl(HIDIOCSFEATURE) on /dev/hidrawN
+    -> hid_hw_raw_request() in kernel HID core
+      -> hid_playstation driver (or hid-generic)
+        -> hidp_set_raw_report() for Bluetooth transport
+          -> Returns -EIO (not implemented)
+```
+
+The `hidp` transport layer's `SET_REPORT` implementation for feature reports returns an error because the Bluetooth HID specification's SET_REPORT transaction is not fully implemented in the Linux `hidp` driver.
+
+Chrome's WebHID takes a different path:
+
+```
+Chrome WebHID API
+  -> Chrome's internal Bluetooth HID client
+    -> BlueZ D-Bus API or direct L2CAP
+      -> SET_REPORT transaction sent directly to device
+```
+
+## Potential Kernel Patch
+
+The `hid_playstation` driver could be patched to pass through SET_REPORT feature reports to the underlying transport. The relevant kernel source files are:
+
+- `drivers/hid/hid-playstation.c` — the PlayStation HID driver
+- `net/bluetooth/hidp/core.c` — the Bluetooth HID transport
+
+### Approach 1: Fix `hidp` SET_REPORT for Feature Reports
+
+The root cause is in `net/bluetooth/hidp/core.c`. The `hidp_set_raw_report()` function needs to properly implement SET_REPORT for feature reports over the Bluetooth control channel (L2CAP). Currently, this code path either returns `-EIO` or is missing entirely.
+
+The fix would involve:
+1. Constructing a `HIDP_TRANS_SET_REPORT | HIDP_DATA_RTYPE_FEATURE` header
+2. Sending the report data over the L2CAP control channel
+3. Waiting for the acknowledgment from the device
+
+This would benefit all Bluetooth HID devices on Linux, not just the DualSense.
+
+### Approach 2: Route Through `uhid`
+
+An alternative approach is to have `hid_playstation` create a `uhid` device alongside the standard hidraw interface, similar to how Chrome's WebHID works. This would allow userspace applications to send feature reports through the `uhid` interface while the kernel driver continues to handle standard input processing.
+
+### Approach 3: Userspace Bluetooth HID
+
+As a library-level workaround, `dualsense-ts` could implement direct L2CAP communication for Bluetooth DualSense controllers on Linux, bypassing the kernel HID stack entirely. This is similar to what Chrome does and would involve:
+
+1. Using the BlueZ D-Bus API to discover and connect to the controller
+2. Opening L2CAP sockets directly to the HID control and interrupt channels
+3. Sending SET_REPORT transactions over the control channel
+
+This approach is complex but would give full feature parity without requiring kernel modifications.
+
+## References
+
+- [Linux kernel HID subsystem documentation](https://www.kernel.org/doc/html/latest/hid/index.html)
+- [Bluetooth HID Profile specification](https://www.bluetooth.com/specifications/specs/human-interface-device-profile-1-1/)
+- [hid-playstation driver source](https://github.com/torvalds/linux/blob/master/drivers/hid/hid-playstation.c)
+- [hidp core source](https://github.com/torvalds/linux/blob/master/net/bluetooth/hidp/core.c)
+- [Chrome WebHID implementation](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/services/device/hid/)
+- [daidr/dualsense-tester](https://github.com/daidr/dualsense-tester) — WebHID reference implementation that works over Bluetooth

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ console.log(controller.right.trigger.feedback.config);
 console.log(controller.right.trigger.feedback.effect); // TriggerEffect.Off
 ```
 
-Feedback state is automatically restored if the controller disconnects and reconnects — no handling required on your end.
+Feedback state is automatically restored if the controller disconnects and reconnects - no handling required on your end.
 
 #### Trigger effects
 
@@ -249,7 +249,7 @@ Feedback state is automatically restored if the controller disconnects and recon
 | `TriggerEffect.Vibration` | Zone-based oscillation with amplitude and frequency        |
 | `TriggerEffect.Machine`   | Dual-amplitude vibration with frequency and period control |
 
-Each effect accepts a unique set of configuration options — your editor's type hints will guide you through the available parameters for each effect. The [interactive demo](https://nsfm.github.io/dualsense-ts/) includes full slider controls for every effect and parameter, making it a great tool for finding the right values.
+Each effect accepts a unique set of configuration options; your editor's type hints will guide you through the available parameters for each effect. The [interactive demo](https://nsfm.github.io/dualsense-ts/) includes full slider controls for every effect and parameter, making it a great tool for finding the right values.
 
 Effect names are based on [Nielk1's DualSense trigger effect documentation](https://gist.github.com/Nielk1/6d54cc2c00d2201ccb8c2720ad7538db).
 
@@ -283,7 +283,7 @@ controller.mute.status.on("change", ({ state }) => {
 });
 ```
 
-The `{r, g, b}` format is directly compatible with popular color libraries — pass the output of `colord().toRgb()`, `tinycolor().toRgb()`, or `Color().object()` straight to `lightbar.set()`.
+The `{r, g, b}` format is compatible with popular color libraries. Pass the output of `colord().toRgb()`, `tinycolor().toRgb()`, or `Color().object()` straight to `lightbar.set()`.
 
 The mute LED cannot be controlled (the firmware toggles it on and off with the button) but you can read its current state. `controller.mute` allows you to read the button like a normal input, while `controller.mute.status` is a toggle input tied to the LED's state.
 
@@ -304,35 +304,37 @@ controller.headphone.state; // true when headphones are plugged in
 controller.microphone.state; // true when a microphone is available
 ```
 
-#### Firmware and Factory Info
+#### Color and Serial Number
 
-After connection, `dualsense-ts` automatically reads firmware details and factory information (including the controller's body color and board revision) from the device:
+`dualsense-ts` reads the controller's body color and serial number from factory info after connection:
 
 ```typescript
-// Firmware info is available shortly after connection
-controller.connection.on("change", ({ state }) => {
-  if (!state) return;
+import { DualsenseColor } from "dualsense-ts";
 
-  // Firmware details (Feature Report 0x20) — available on all connection types
-  const fw = controller.firmwareInfo;
-  if (fw) {
-    const v = fw.mainFirmwareVersion;
-    console.log(`Firmware: ${v.major}.${v.minor}.${v.patch}`);
-    console.log(`Built: ${fw.buildDate} ${fw.buildTime}`);
-    console.log(`Hardware: ${fw.hardwareInfo}`);
-  }
-
-  // Factory info (test command protocol) — requires USB or WebHID, see note below
-  const fi = controller.factoryInfo;
-  if (fi) {
-    console.log(`Color: ${fi.colorName}`); // e.g. "Cosmic Red"
-    console.log(`Board: ${fi.boardRevision}`); // e.g. "BDM-030"
-    console.log(`Serial: ${fi.serialNumber}`);
-  }
-});
+controller.color; // DualsenseColor.CosmicRed
+controller.serialNumber; // Factory-stamped serial number
 ```
 
-The `firmwareInfo` property includes build date/time, firmware versions (main, SBL, DSP, Spider DSP), hardware info, and device info. The `factoryInfo` property includes the controller's body color, board revision, and serial number.
+`color` returns a `DualsenseColor` enum value (`DualsenseColor.Unknown` when factory info is unavailable).
+
+#### Firmware and Factory Info
+
+`dualsense-ts` automatically reads firmware details and factory information from the device after connection. These values may take a moment to populate.
+
+```typescript
+const fw = controller.firmwareInfo;
+const v = fw.mainFirmwareVersion;
+console.log(`Firmware: ${v.major}.${v.minor}.${v.patch}`);
+console.log(`Built: ${fw.buildDate} ${fw.buildTime}`);
+console.log(`Hardware: ${fw.hardwareInfo}`);
+
+const fi = controller.factoryInfo;
+console.log(`Color: ${fi.colorName}`); // e.g. "Cosmic Red"
+console.log(`Board: ${fi.boardRevision}`); // e.g. "BDM-030"
+console.log(`Serial: ${fi.serialNumber}`);
+```
+
+The `firmwareInfo` property includes build date/time, firmware versions, hardware info, and device info. The `factoryInfo` property includes the controller's body color, board revision, and serial number.
 
 ## Using `dualsense-ts` with React
 
@@ -466,7 +468,7 @@ manager.get(0)?.playerLeds.setBrightness(Brightness.Low);
 
 ### Reconnection
 
-When a controller disconnects, its slot is preserved. If the same controller reconnects - even through a different connection type (USB to Bluetooth or vice versa) - it returns to its original slot with the same player number. In Node.js, reconnection matching uses the hardware serial number. In the browser, it is best-effort based on device identity.
+When a controller disconnects, its slot is preserved. If the same controller reconnects - even through a different connection type (USB to Bluetooth or vice versa) - it returns to its original slot with the same player number. Reconnection matching uses hardware identity read directly from the controller's firmware.
 
 ### Slot management
 

--- a/README.md
+++ b/README.md
@@ -304,6 +304,36 @@ controller.headphone.state; // true when headphones are plugged in
 controller.microphone.state; // true when a microphone is available
 ```
 
+#### Firmware and Factory Info
+
+After connection, `dualsense-ts` automatically reads firmware details and factory information (including the controller's body color and board revision) from the device:
+
+```typescript
+// Firmware info is available shortly after connection
+controller.connection.on("change", ({ state }) => {
+  if (!state) return;
+
+  // Firmware details (Feature Report 0x20) — available on all connection types
+  const fw = controller.firmwareInfo;
+  if (fw) {
+    const v = fw.mainFirmwareVersion;
+    console.log(`Firmware: ${v.major}.${v.minor}.${v.patch}`);
+    console.log(`Built: ${fw.buildDate} ${fw.buildTime}`);
+    console.log(`Hardware: ${fw.hardwareInfo}`);
+  }
+
+  // Factory info (test command protocol) — requires USB or WebHID, see note below
+  const fi = controller.factoryInfo;
+  if (fi) {
+    console.log(`Color: ${fi.colorName}`); // e.g. "Cosmic Red"
+    console.log(`Board: ${fi.boardRevision}`); // e.g. "BDM-030"
+    console.log(`Serial: ${fi.serialNumber}`);
+  }
+});
+```
+
+The `firmwareInfo` property includes build date/time, firmware versions (main, SBL, DSP, Spider DSP), hardware info, and device info. The `factoryInfo` property includes the controller's body color, board revision, and serial number.
+
 ## Using `dualsense-ts` with React
 
 Check out [the example app](./webhid_example/) for more details.
@@ -459,7 +489,13 @@ Using `new Dualsense()` directly continues to work exactly as before, allowing y
 
 ## Known Issues
 
-In Linux, identical devices may not be given separate HID interfaces under some circumstances. This may limit your ability to use multiple controllers simultaneously. In this situation, one wired and one wireless controller is still a valid configuration.
+### Linux - can't use multiple controllers over Bluetooth
+
+Identical Bluetooth devices are not given separate HID interfaces under some circumstances. You may still use multiple USB-connected controllers plus one Bluetooth controller.
+
+### Linux - can't access factory info over Bluetooth connection in Node.js
+
+Factory info uses the HID SET_REPORT feature report protocol, which the Linux kernel's `hid_playstation` driver does not pass through over Bluetooth. As a result, `factoryInfo` is only available over USB when using `node-hid` on Linux. In the browser, WebHID bypasses the kernel driver and works on all connection types. See [LINUX_HID.md](LINUX_HID.md) for investigation details.
 
 ## Other Dualsense Variants
 
@@ -473,7 +509,8 @@ The PS4 DualShock controller is not supported.
 
 ## Credits
 
-- [CamTosh](https://github.com/CamTosh)'s [node-dualsense](https://github.com/CamTosh/node-dualsense)
-- [flok](https://github.com/flok)'s [pydualsense](https://github.com/flok/pydualsense)
-- [nondebug](https://github.com/nondebug)'s [dualsense reference](https://github.com/nondebug/dualsense)
+- [CamTosh](https://github.com/CamTosh)'s [node-dualsense](https://github.com/CamTosh/node-dualsense) - HID report reference
+- [flok](https://github.com/flok)'s [pydualsense](https://github.com/flok/pydualsense) - HID report reference
+- [nondebug](https://github.com/nondebug)'s [dualsense reference](https://github.com/nondebug/dualsense) - WebHID reference
+- [daidr](https://github.com/daidr)'s [dualsense-tester](https://github.com/daidr/dualsense-tester) — firmware/factory info reference
 - [Contributors to `dualsense-ts` on Github](https://github.com/nsfm/dualsense-ts/graphs/contributors)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,22 @@
 # dualsense-ts
 
-`dualsense-ts` is the natural interface for your DualSense controller. It's fully-typed, fully-featured, easy to use, and supports wired and wireless connections in both node.js and the browser.
+`dualsense-ts` is the natural interface for your DualSense controller. Simple to use, fully-typed, fully-featured, and supports wired and wireless connections in both node.js and the browser.
 
 **[Live demo](https://nsfm.github.io/dualsense-ts/)** - connect a controller and try it out!
+
+## Features
+
+- **Rich input API** providing synchronous, event, iterator, or promise-based updates
+- **Bluetooth and USB** support in the browser or node.js
+- **Automatic connection and reconnection** even when connection type changes
+- **Multiplayer support**, allowing up to 31 connected controllers at a time
+- **Lighting control** - RGB light bars, player LEDs, and mute button
+- **Full haptics control** - independent left/right rumble plus complete trigger haptic configuration
+- **Touchpad support** with full multi-touch handling
+- **Motion tracking** via gyroscope and accelerometer readings
+- **Battery status** including level and charging state
+- **Peripheral status** for connected headphones and microphone
+- **Firmware info** checks providing controller color, hardware/software versions, and more
 
 ## Getting started
 
@@ -426,12 +440,14 @@ manager.on("change", ({ active, players }) => {
 });
 ```
 
-In Node.js, the manager polls for new devices automatically. In the browser, you'll need to request permission via a user gesture:
+In Node.js, the manager polls for new devices automatically. In the browser, you'll still need to request permission via a user gesture:
 
 ```typescript
 // React / plain JS
 <button onClick={manager.getRequest()}>Add Controllers</button>
 ```
+
+This only applies to the first connection for each controller.
 
 ### Accessing controllers
 
@@ -468,7 +484,7 @@ manager.get(0)?.playerLeds.setBrightness(Brightness.Low);
 
 ### Reconnection
 
-When a controller disconnects, its slot is preserved. If the same controller reconnects - even through a different connection type (USB to Bluetooth or vice versa) - it returns to its original slot with the same player number. Reconnection matching uses hardware identity read directly from the controller's firmware.
+When a controller disconnects, its slot is preserved. If the same controller reconnects, even through a different connection type (USB to Bluetooth or vice versa), it returns to its original slot with the same player number. Reconnection matching uses hardware identity provided by the controller's firmware.
 
 ### Slot management
 
@@ -497,7 +513,7 @@ Identical Bluetooth devices are not given separate HID interfaces under some cir
 
 ### Linux - can't access factory info over Bluetooth connection in Node.js
 
-Factory info uses the HID SET_REPORT feature report protocol, which the Linux kernel's `hid_playstation` driver does not pass through over Bluetooth. Factory info is still available over USB or Bluetooth in the browser. See [LINUX_HID.md](LINUX_HID.md) for investigation details.
+Factory info uses the HID SET_REPORT feature report protocol, which the Linux kernel's `hid_playstation` driver does not pass through over Bluetooth. This mainly limits your ability to check the controller's body color and serial number. Factory info is still available over USB or Bluetooth in the browser. See [LINUX_HID.md](LINUX_HID.md) for investigation details.
 
 ## Other Dualsense Variants
 

--- a/README.md
+++ b/README.md
@@ -497,7 +497,7 @@ Identical Bluetooth devices are not given separate HID interfaces under some cir
 
 ### Linux - can't access factory info over Bluetooth connection in Node.js
 
-Factory info uses the HID SET_REPORT feature report protocol, which the Linux kernel's `hid_playstation` driver does not pass through over Bluetooth. As a result, `factoryInfo` is only available over USB when using `node-hid` on Linux. In the browser, WebHID bypasses the kernel driver and works on all connection types. See [LINUX_HID.md](LINUX_HID.md) for investigation details.
+Factory info uses the HID SET_REPORT feature report protocol, which the Linux kernel's `hid_playstation` driver does not pass through over Bluetooth. Factory info is still available over USB or Bluetooth in the browser. See [LINUX_HID.md](LINUX_HID.md) for investigation details.
 
 ## Other Dualsense Variants
 
@@ -515,4 +515,5 @@ The PS4 DualShock controller is not supported.
 - [flok](https://github.com/flok)'s [pydualsense](https://github.com/flok/pydualsense) - HID report reference
 - [nondebug](https://github.com/nondebug)'s [dualsense reference](https://github.com/nondebug/dualsense) - WebHID reference
 - [daidr](https://github.com/daidr)'s [dualsense-tester](https://github.com/daidr/dualsense-tester) — firmware/factory info reference
+- [nowrep](https://github.com/nowrep)'s [dualsensectl](https://github.com/nowrep/dualsensectl) - firmware info reference
 - [Contributors to `dualsense-ts` on Github](https://github.com/nsfm/dualsense-ts/graphs/contributors)

--- a/nodehid_example/debug.ts
+++ b/nodehid_example/debug.ts
@@ -2,6 +2,7 @@ import { Dualsense } from "../src/dualsense";
 import { DualsenseManager } from "../src/manager";
 import { TriggerEffect } from "../src/elements/trigger_feedback";
 import { ChargeStatus } from "../src/hid/battery_state";
+import { formatFirmwareVersion } from "../src/hid/firmware_info";
 
 /** Map a -1..1 stick value to 0..1 */
 function norm(value: number): number {
@@ -27,6 +28,17 @@ function bindController(controller: Dualsense, player: number) {
       if (controller.serialNumber) {
         log(player, `Serial: ${controller.serialNumber}`);
       }
+      // Log firmware and factory info once available
+      setTimeout(() => {
+        const fw = controller.firmwareInfo;
+        if (fw) {
+          log(player, `Firmware: v${formatFirmwareVersion(fw.mainFirmwareVersion)} | HW: ${fw.hardwareInfo} | DSP: ${fw.dspFirmwareVersion} | Built: ${fw.buildDate} ${fw.buildTime}`);
+        }
+        const fi = controller.factoryInfo;
+        if (fi) {
+          log(player, `Factory: ${fi.colorName ?? fi.colorCode} | ${fi.boardRevision ?? "unknown board"} | Serial: ${fi.serialNumber}`);
+        }
+      }, 2000);
     }
   });
 

--- a/nodehid_example/debug.ts
+++ b/nodehid_example/debug.ts
@@ -31,13 +31,9 @@ function logIdentity(controller: Dualsense, player: number) {
     log(player, `Identity: ${controller.hid.identity}`);
   }
   const fw = controller.firmwareInfo;
-  if (fw) {
-    log(player, `Firmware: v${formatFirmwareVersion(fw.mainFirmwareVersion)} | HW: ${fw.hardwareInfo} | DSP: ${fw.dspFirmwareVersion} | Built: ${fw.buildDate} ${fw.buildTime}`);
-  }
+  log(player, `Firmware: v${formatFirmwareVersion(fw.mainFirmwareVersion)} | HW: ${fw.hardwareInfo} | DSP: ${fw.dspFirmwareVersion} | Built: ${fw.buildDate} ${fw.buildTime}`);
   const fi = controller.factoryInfo;
-  if (fi) {
-    log(player, `Factory: ${fi.colorName ?? fi.colorCode} | ${fi.boardRevision ?? "unknown board"} | Serial: ${fi.serialNumber}`);
-  }
+  log(player, `Factory: ${fi.colorName} | ${fi.boardRevision} | Serial: ${fi.serialNumber}`);
 }
 
 /** Set up all debug bindings for a single controller */

--- a/nodehid_example/debug.ts
+++ b/nodehid_example/debug.ts
@@ -14,32 +14,46 @@ function log(player: number, ...args: unknown[]) {
   console.log(`[P${player + 1}]`, ...args);
 }
 
+/** Log transport-level connection details (available immediately) */
+function logConnection(controller: Dualsense, player: number) {
+  const connected = controller.connection.active;
+  log(
+    player,
+    `Connected: ${connected ? "yes" : "no"} - ${
+      connected ? (controller.wireless ? "bluetooth" : "usb") : ""
+    }`,
+  );
+}
+
+/** Log firmware/factory identity (available after onReady) */
+function logIdentity(controller: Dualsense, player: number) {
+  if (controller.hid.identity) {
+    log(player, `Identity: ${controller.hid.identity}`);
+  }
+  const fw = controller.firmwareInfo;
+  if (fw) {
+    log(player, `Firmware: v${formatFirmwareVersion(fw.mainFirmwareVersion)} | HW: ${fw.hardwareInfo} | DSP: ${fw.dspFirmwareVersion} | Built: ${fw.buildDate} ${fw.buildTime}`);
+  }
+  const fi = controller.factoryInfo;
+  if (fi) {
+    log(player, `Factory: ${fi.colorName ?? fi.colorCode} | ${fi.boardRevision ?? "unknown board"} | Serial: ${fi.serialNumber}`);
+  }
+}
+
 /** Set up all debug bindings for a single controller */
 function bindController(controller: Dualsense, player: number) {
-  controller.connection.on("change", ({ state }) => {
-    log(
-      player,
-      `Connected: ${state ? "yes" : "no"} - ${
-        state ? (controller.wireless ? "bluetooth" : "usb") : ""
-      }`,
-    );
-    if (state) {
-      log(player, `Device: ${controller.deviceId ?? "unknown"}`);
-      if (controller.serialNumber) {
-        log(player, `Serial: ${controller.serialNumber}`);
-      }
-      // Log firmware and factory info once available
-      setTimeout(() => {
-        const fw = controller.firmwareInfo;
-        if (fw) {
-          log(player, `Firmware: v${formatFirmwareVersion(fw.mainFirmwareVersion)} | HW: ${fw.hardwareInfo} | DSP: ${fw.dspFirmwareVersion} | Built: ${fw.buildDate} ${fw.buildTime}`);
-        }
-        const fi = controller.factoryInfo;
-        if (fi) {
-          log(player, `Factory: ${fi.colorName ?? fi.colorCode} | ${fi.boardRevision ?? "unknown board"} | Serial: ${fi.serialNumber}`);
-        }
-      }, 2000);
-    }
+  // Log the current connection state immediately.
+  logConnection(controller, player);
+
+  controller.connection.on("change", () => {
+    logConnection(controller, player);
+  });
+
+  // Log identity details once firmware/factory info is available. On
+  // initial bind onReady fires synchronously (already resolved). On
+  // reconnect it fires after the background verification completes.
+  controller.hid.onReady(() => {
+    logIdentity(controller, player);
   });
 
   // Log battery level on connect and when it changes

--- a/nodehid_example/single.ts
+++ b/nodehid_example/single.ts
@@ -1,6 +1,7 @@
 import { Dualsense } from "../src/dualsense";
 import { TriggerEffect } from "../src/elements/trigger_feedback";
 import { ChargeStatus } from "../src/hid/battery_state";
+import { formatFirmwareVersion } from "../src/hid/firmware_info";
 
 /** Map a -1..1 stick value to 0..1 */
 function norm(value: number): number {
@@ -18,6 +19,26 @@ function main() {
         state ? (controller.wireless ? "bluetooth" : "usb") : ""
       }`,
     );
+    if (state) {
+      setTimeout(() => {
+        const fw = controller.firmwareInfo;
+        if (fw) {
+          console.log(
+            `Firmware: v${formatFirmwareVersion(fw.mainFirmwareVersion)} | HW: ${fw.hardwareInfo} | DSP: ${fw.dspFirmwareVersion} | Built: ${fw.buildDate} ${fw.buildTime}`,
+          );
+        } else {
+          console.log("Failed to query device firmware info");
+        }
+        const fi = controller.factoryInfo;
+        if (fi) {
+          console.log(
+            `Factory: ${fi.colorName ?? fi.colorCode} | ${fi.boardRevision ?? "unknown board"} | Serial: ${fi.serialNumber}`,
+          );
+        } else {
+          console.log("Failed to query device factory info");
+        }
+      }, 2000);
+    }
   });
 
   // Battery

--- a/src/dualsense.ts
+++ b/src/dualsense.ts
@@ -25,6 +25,8 @@ import {
   PulseOptions,
   FirmwareInfo,
   FactoryInfo,
+  DualsenseColor,
+  DualsenseColorMap,
 } from "./hid";
 import { Intensity } from "./math";
 
@@ -107,28 +109,39 @@ export class Dualsense extends Input<Dualsense> {
   /** The 5 white player indicator LEDs */
   public readonly playerLeds = new PlayerLeds();
 
-  /** Buffered battery reading, sampled on a slow cadence */
+  /**
+   * Buffered battery reading, sampled on a slow cadence
+   * Battery readings are prone to flip-flopping, so we buffer them
+   */
   private readonly pendingBattery = {
     peakLevel: 0,
     status: ChargeStatus.Discharging as ChargeStatus,
   };
 
-  /** Represents the underlying HID device. Provides input events */
+  /** Represents the underlying HID device. Provides input events. */
   public readonly hid: DualsenseHID;
 
-  /** Firmware and hardware information, populated after connection */
-  public get firmwareInfo(): FirmwareInfo | undefined {
+  /**
+   * Firmware and hardware information.
+   * Contains sensible defaults until the device reports its actual values.
+   */
+  public get firmwareInfo(): FirmwareInfo {
     return this.hid.firmwareInfo;
   }
 
-  /** Factory information (serial number, body color, board revision), populated after connection */
-  public get factoryInfo(): FactoryInfo | undefined {
+  /**
+   * Factory information (serial number, body color, board revision).
+   * Contains sensible defaults until the device reports its actual values.
+   * On Linux over Bluetooth the defaults persist (kernel limitation).
+   */
+  public get factoryInfo(): FactoryInfo {
     return this.hid.factoryInfo;
   }
 
   /** A virtual button representing whether or not a controller is connected */
   public readonly connection: Momentary;
 
+  /** True if any input at all is active or changing */
   public get active(): boolean {
     return Object.values(this).some(
       (input) => input !== this && input instanceof Input && input.active,
@@ -140,14 +153,16 @@ export class Dualsense extends Input<Dualsense> {
     return this.hid.wireless;
   }
 
-  /** Unique identifier for the connected device (path or fingerprint) */
-  public get deviceId(): string | undefined {
-    return this.hid.provider.deviceId;
+  /** Body color of the controller */
+  public get color(): DualsenseColor {
+    const { colorCode } = this.hid.factoryInfo;
+    if (colorCode in DualsenseColorMap) return DualsenseColorMap[colorCode];
+    return DualsenseColor.Unknown;
   }
 
-  /** Hardware serial number of the connected device, if available */
-  public get serialNumber(): string | undefined {
-    return this.hid.provider.serialNumber;
+  /** Factory-stamped serial number of the controller */
+  public get serialNumber(): string {
+    return this.hid.factoryInfo.serialNumber;
   }
 
   constructor(params: DualsenseParams = {}) {
@@ -239,6 +254,10 @@ export class Dualsense extends Input<Dualsense> {
     });
 
     this.connection[InputSet](false);
+    // If a HID instance was supplied externally (e.g. by DualsenseManager),
+    // the owner is responsible for driving discovery + reconnection. Otherwise
+    // construct a default platform provider and run our own discovery loop.
+    const externallyManaged = params.hid != null;
     this.hid = params.hid ?? new DualsenseHID(new PlatformHIDProvider());
     this.hid.register((state: DualsenseHIDState) => {
       this.processHID(state);
@@ -249,26 +268,32 @@ export class Dualsense extends Input<Dualsense> {
     const lightbarMemo = { key: "" };
     const playerLedsMemo = { key: "" };
 
-    /** Refresh connection state */
-    let lastConnected = false;
-    setInterval(() => {
-      const {
-        provider: { connected },
-      } = this.hid;
-
+    // Mirror transport-level connect/disconnect into the connection Momentary,
+    // and invalidate output memos on rising-edge connect so the output loop
+    // re-pushes desired state to the new device.
+    this.hid.onConnectionChange((connected) => {
       this.connection[InputSet](connected);
-      if (connected && !lastConnected) {
-        // Invalidate memos so the output loop restores desired state on reconnect.
+      if (connected) {
         triggerFeedbackMemo.left = "";
         triggerFeedbackMemo.right = "";
         lightbarMemo.key = "";
         playerLedsMemo.key = "";
-        // Read firmware and factory info on each new connection
-        void this.hid.fetchFirmwareInfo().then(() => this.hid.fetchFactoryInfo());
       }
-      lastConnected = connected;
-      if (!connected) this.hid.provider.connect();
-    }, 200);
+    });
+    // Seed the initial state in case the provider was already attached.
+    this.connection[InputSet](this.hid.provider.connected);
+
+    // Standalone mode: poll for devices and reconnect on drop. In managed
+    // mode the manager owns this and we must NOT race with it.
+    if (!externallyManaged) {
+      setInterval(() => {
+        if (!this.hid.provider.connected) {
+          void Promise.resolve(this.hid.provider.connect()).catch(() => {
+            /* surfaced via onError */
+          });
+        }
+      }, 200);
+    }
 
     /** Refresh battery state on a slow cadence to filter transient glitches */
     setInterval(() => {
@@ -328,13 +353,16 @@ export class Dualsense extends Input<Dualsense> {
 
       const playerLedsKey = this.playerLeds.toKey();
       if (playerLedsKey !== playerLedsMemo.key) {
-        this.hid.setPlayerLeds(this.playerLeds.bitmask, this.playerLeds.brightness);
+        this.hid.setPlayerLeds(
+          this.playerLeds.bitmask,
+          this.playerLeds.brightness,
+        );
         playerLedsMemo.key = playerLedsKey;
       }
-
     }, 1000 / 30);
   }
 
+  /** Average rumble strength across both halves of the controller. */
   private get rumbleIntensity(): number {
     return (this.left.rumble() + this.right.rumble()) / 2;
   }
@@ -352,7 +380,7 @@ export class Dualsense extends Input<Dualsense> {
     return this.rumbleIntensity;
   }
 
-  /** Distributes HID event values to the controller's inputs */
+  /** Distributes HID event values to the controller's public inputs. */
   private processHID(state: DualsenseHIDState): void {
     this.ps[InputSet](state[InputId.Playstation]);
     this.options[InputSet](state[InputId.Options]);

--- a/src/dualsense.ts
+++ b/src/dualsense.ts
@@ -23,6 +23,8 @@ import {
   InputId,
   ChargeStatus,
   PulseOptions,
+  FirmwareInfo,
+  FactoryInfo,
 } from "./hid";
 import { Intensity } from "./math";
 
@@ -113,6 +115,16 @@ export class Dualsense extends Input<Dualsense> {
 
   /** Represents the underlying HID device. Provides input events */
   public readonly hid: DualsenseHID;
+
+  /** Firmware and hardware information, populated after connection */
+  public get firmwareInfo(): FirmwareInfo | undefined {
+    return this.hid.firmwareInfo;
+  }
+
+  /** Factory information (serial number, body color, board revision), populated after connection */
+  public get factoryInfo(): FactoryInfo | undefined {
+    return this.hid.factoryInfo;
+  }
 
   /** A virtual button representing whether or not a controller is connected */
   public readonly connection: Momentary;
@@ -251,6 +263,8 @@ export class Dualsense extends Input<Dualsense> {
         triggerFeedbackMemo.right = "";
         lightbarMemo.key = "";
         playerLedsMemo.key = "";
+        // Read firmware and factory info on each new connection
+        void this.hid.fetchFirmwareInfo().then(() => this.hid.fetchFactoryInfo());
       }
       lastConnected = connected;
       if (!connected) this.hid.provider.connect();

--- a/src/hid/bt_checksum.ts
+++ b/src/hid/bt_checksum.ts
@@ -56,3 +56,42 @@ export function computeBluetoothReportChecksum(buffer: Uint8Array): number {
   return result >>> 0;
 }
 
+/** Standard CRC-32 lookup table (polynomial 0xEDB88320) */
+const crc32Table: number[] = (() => {
+  const table: number[] = [];
+  for (let n = 0; n < 256; n++) {
+    let c = n;
+    for (let k = 0; k < 8; k++) {
+      c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    }
+    table[n] = c >>> 0;
+  }
+  return table;
+})();
+
+/**
+ * Compute CRC-32 for a Bluetooth feature report.
+ * The CRC covers the HID transaction header (0x53), the report ID,
+ * and all payload bytes except the last 4 (which hold the CRC itself).
+ * Uses standard CRC-32 with final inversion.
+ */
+export function computeFeatureReportChecksum(
+  reportId: number,
+  buffer: Uint8Array,
+): number {
+  let crc = 0xffffffff >>> 0;
+
+  // Feed prefix bytes: 0x53 (SET_REPORT feature) + report ID
+  crc = (crc >>> 8) ^ crc32Table[(crc ^ 0x53) & 0xff];
+  crc = (crc >>> 8) ^ crc32Table[(crc ^ reportId) & 0xff];
+
+  // Feed payload data (exclude last 4 bytes reserved for CRC)
+  const dataLen = buffer.length - 4;
+  for (let i = 0; i < dataLen; i++) {
+    crc = (crc >>> 8) ^ crc32Table[(crc ^ buffer[i]) & 0xff];
+  }
+
+  // Final XOR (standard CRC-32 finalization)
+  return (crc ^ 0xffffffff) >>> 0;
+}
+

--- a/src/hid/dualsense_hid.ts
+++ b/src/hid/dualsense_hid.ts
@@ -5,11 +5,13 @@ import {
   DefaultDualsenseHIDState,
 } from "./hid_provider";
 import { computeBluetoothReportChecksum } from "./bt_checksum";
-import { FirmwareInfo, readFirmwareInfo } from "./firmware_info";
-import { FactoryInfo, readFactoryInfo } from "./factory_info";
+import { FirmwareInfo, DefaultFirmwareInfo, readFirmwareInfo } from "./firmware_info";
+import { FactoryInfo, DefaultFactoryInfo, readFactoryInfo } from "./factory_info";
 
 export type HIDCallback = (state: DualsenseHIDState) => void;
 export type ErrorCallback = (error: Error) => void;
+export type ReadyCallback = () => void;
+export type ConnectionCallback = (connected: boolean) => void;
 
 const SCOPE_A = 1;
 const SCOPE_B = 2;
@@ -30,14 +32,24 @@ export class DualsenseHID {
   private readonly subscribers = new Set<HIDCallback>();
   /** Subscribers waiting for error updates */
   private readonly errorSubscribers = new Set<ErrorCallback>();
+  /** Subscribers waiting for firmware/factory info to become available */
+  private readonly readySubscribers = new Set<ReadyCallback>();
+  /** Subscribers tracking transport-level connect/disconnect events */
+  private readonly connectionSubscribers = new Set<ConnectionCallback>();
+  /** True once firmware/factory info has been loaded for the current connection */
+  private identityResolved = false;
+  /** Pending retry timer for identity loading after a transient failure */
+  private identityRetryTimer?: ReturnType<typeof setTimeout>;
+  /** Number of identity-load attempts made for the current connection */
+  private identityRetryCount = 0;
   /** Queue of pending HID commands */
   private pendingCommands: CommandEvent[] = [];
   /** Most recent HID state of the device */
   public state: DualsenseHIDState = { ...DefaultDualsenseHIDState };
   /** Firmware and hardware information, populated after connection */
-  public firmwareInfo?: FirmwareInfo;
+  public firmwareInfo: FirmwareInfo = DefaultFirmwareInfo;
   /** Factory information (serial, color, board revision), populated after connection */
-  public factoryInfo?: FactoryInfo;
+  public factoryInfo: FactoryInfo = DefaultFactoryInfo;
 
   constructor(
     readonly provider: HIDProvider,
@@ -45,6 +57,24 @@ export class DualsenseHID {
   ) {
     provider.onData = this.set.bind(this);
     provider.onError = this.handleError.bind(this);
+    provider.onConnect = () => {
+      // Keep cached firmware/factory info from the prior session so that
+      // consumers see identity details immediately on a reconnection
+      // event. The background loadIdentity() call will verify and refresh
+      // the cache — if the hardware identity turns out different (e.g. a
+      // different controller grabbed the same slot), the fields get
+      // overwritten then.
+      this.firmwareFetch = undefined;
+      this.factoryFetch = undefined;
+      this.identityResolved = false;
+      this.cancelIdentityRetry();
+      this.connectionSubscribers.forEach((cb) => cb(true));
+      void this.loadIdentity();
+    };
+    provider.onDisconnect = () => {
+      this.cancelIdentityRetry();
+      this.connectionSubscribers.forEach((cb) => cb(false));
+    };
 
     setInterval(() => {
       if (this.pendingCommands.length > 0) {
@@ -85,6 +115,53 @@ export class DualsenseHID {
     if (type === "error") this.errorSubscribers.add(callback);
   }
 
+  /**
+   * Subscribe to notification when firmware/factory info finishes loading
+   * after a connect. Fires once per connection — either when identity has
+   * been resolved, or when we've given up retrying. If identity is already
+   * resolved at the time of subscription, the callback fires synchronously.
+   */
+  public onReady(callback: ReadyCallback): () => void {
+    if (this.identityResolved) {
+      callback();
+      return () => {};
+    }
+    this.readySubscribers.add(callback);
+    return () => this.readySubscribers.delete(callback);
+  }
+
+  /** True if firmware/factory info has been loaded (or given up on) for the current connection */
+  public get ready(): boolean {
+    return this.identityResolved;
+  }
+
+  /**
+   * Subscribe to transport-level connect/disconnect events. Useful for
+   * mirroring connection state into an Input without polling. Returns
+   * an unsubscribe function.
+   */
+  public onConnectionChange(callback: ConnectionCallback): () => void {
+    this.connectionSubscribers.add(callback);
+    return () => this.connectionSubscribers.delete(callback);
+  }
+
+  /**
+   * Stable hardware identity for this controller, derived from the most
+   * trustworthy info available. Prefers the factory serial (32-char ASCII
+   * stamped at the factory), then falls back to the firmware deviceInfo
+   * blob (12 hex bytes available on every transport on every platform).
+   * Returns undefined until firmware info has been read.
+   */
+  public get identity(): string | undefined {
+    if (this.factoryInfo.serialNumber !== DefaultFactoryInfo.serialNumber) {
+      return `serial:${this.factoryInfo.serialNumber}`;
+    }
+    if (this.firmwareInfo.deviceInfo !== DefaultFirmwareInfo.deviceInfo) {
+      return `device:${this.firmwareInfo.deviceInfo}`;
+    }
+    return undefined;
+  }
+
   /** Update the HID state and pass it along to all state subscribers */
   private set(state: DualsenseHIDState): void {
     this.state = state;
@@ -96,24 +173,141 @@ export class DualsenseHID {
     this.errorSubscribers.forEach((callback) => callback(error));
   }
 
-  /** Read firmware info from the controller (Feature Report 0x20) */
-  public async fetchFirmwareInfo(): Promise<FirmwareInfo | undefined> {
-    this.firmwareInfo = await readFirmwareInfo(this.provider);
-    return this.firmwareInfo;
+  /** Maximum identity-load retry attempts per connection */
+  private static readonly IDENTITY_MAX_ATTEMPTS = 5;
+  /** Backoff schedule (ms) for identity-load retries */
+  private static readonly IDENTITY_BACKOFF_MS = [500, 1500, 3000, 5000];
+
+  /**
+   * Attempt to read firmware + factory info for the current connection,
+   * with retry on failure. Marks identity as resolved on success or after
+   * exhausting all attempts (so consumers don't wait forever).
+   *
+   * If cached firmware/factory info exists from a prior session, identity
+   * is resolved immediately (so the connection event has full details),
+   * then a background verification re-reads the device to confirm.
+   */
+  private async loadIdentity(): Promise<void> {
+    if (!this.provider.connected) return;
+
+    // Fast path: if we already have cached identity from a prior session,
+    // mark resolved immediately so consumers see it on the connection event.
+    // Then continue to the verification read below.
+    const hadCachedIdentity = this.identity !== undefined;
+    if (hadCachedIdentity) {
+      this.markIdentityResolved();
+    }
+
+    this.identityRetryCount += 1;
+
+    try {
+      // Always read fresh from the device (bypass the idempotency cache).
+      const fw = await readFirmwareInfo(this.provider);
+      if (fw) {
+        this.firmwareInfo = fw;
+        this.firmwareFetch = Promise.resolve(fw);
+
+        const fi = await readFactoryInfo(
+          this.provider,
+          fw.hardwareInfo,
+          fw.mainFirmwareVersionRaw,
+        );
+        this.factoryInfo = fi ?? DefaultFactoryInfo;
+        this.factoryFetch = Promise.resolve(this.factoryInfo);
+
+        if (!hadCachedIdentity) {
+          this.markIdentityResolved();
+        }
+        return;
+      }
+    } catch {
+      // Treat throws the same as undefined — fall through to retry logic.
+    }
+
+    // Failure — clear in-flight promises so the next attempt can retry.
+    this.firmwareFetch = undefined;
+    this.factoryFetch = undefined;
+
+    if (
+      this.identityRetryCount >= DualsenseHID.IDENTITY_MAX_ATTEMPTS ||
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      !this.provider.connected
+    ) {
+      this.markIdentityResolved();
+      return;
+    }
+
+    const delay =
+      DualsenseHID.IDENTITY_BACKOFF_MS[
+        Math.min(
+          this.identityRetryCount - 1,
+          DualsenseHID.IDENTITY_BACKOFF_MS.length - 1,
+        )
+      ];
+    this.identityRetryTimer = setTimeout(() => {
+      this.identityRetryTimer = undefined;
+      void this.loadIdentity();
+    }, delay);
+  }
+
+  /** Mark identity loading as complete and notify subscribers */
+  private markIdentityResolved(): void {
+    if (this.identityResolved) return;
+    this.identityResolved = true;
+    this.identityRetryCount = 0;
+    const callbacks = Array.from(this.readySubscribers);
+    this.readySubscribers.clear();
+    callbacks.forEach((cb) => cb());
+  }
+
+  /** Cancel any pending identity-load retry */
+  private cancelIdentityRetry(): void {
+    if (this.identityRetryTimer) {
+      clearTimeout(this.identityRetryTimer);
+      this.identityRetryTimer = undefined;
+    }
+    this.identityRetryCount = 0;
+  }
+
+  /** In-flight firmware info fetch, deduped across callers within a connection */
+  private firmwareFetch?: Promise<FirmwareInfo>;
+  /** In-flight factory info fetch, deduped across callers within a connection */
+  private factoryFetch?: Promise<FactoryInfo>;
+
+  /**
+   * Read firmware info from the controller (Feature Report 0x20).
+   * Idempotent: returns the cached value if already fetched, or the
+   * in-flight promise if a fetch is already underway.
+   */
+  public fetchFirmwareInfo(): Promise<FirmwareInfo> {
+    if (this.firmwareInfo !== DefaultFirmwareInfo) return Promise.resolve(this.firmwareInfo);
+    if (this.firmwareFetch) return this.firmwareFetch;
+    this.firmwareFetch = readFirmwareInfo(this.provider).then((info) => {
+      this.firmwareInfo = info ?? DefaultFirmwareInfo;
+      return this.firmwareInfo;
+    });
+    return this.firmwareFetch;
   }
 
   /**
    * Read factory info (serial number, body color, board revision) from the controller.
    * Requires firmware info to be fetched first for feature gating.
+   * Idempotent across the lifetime of a single connection.
    */
-  public async fetchFactoryInfo(): Promise<FactoryInfo | undefined> {
-    if (!this.firmwareInfo) return undefined;
-    this.factoryInfo = await readFactoryInfo(
+  public fetchFactoryInfo(): Promise<FactoryInfo> {
+    if (this.factoryInfo !== DefaultFactoryInfo) return Promise.resolve(this.factoryInfo);
+    if (this.factoryFetch) return this.factoryFetch;
+    if (this.firmwareInfo === DefaultFirmwareInfo) return Promise.resolve(DefaultFactoryInfo);
+    const fwInfo = this.firmwareInfo;
+    this.factoryFetch = readFactoryInfo(
       this.provider,
-      this.firmwareInfo.hardwareInfo,
-      this.firmwareInfo.mainFirmwareVersionRaw,
-    );
-    return this.factoryInfo;
+      fwInfo.hardwareInfo,
+      fwInfo.mainFirmwareVersionRaw,
+    ).then((info) => {
+      this.factoryInfo = info ?? DefaultFactoryInfo;
+      return this.factoryInfo;
+    });
+    return this.factoryFetch;
   }
 
   /** Condense all pending commands into one HID feature report */

--- a/src/hid/dualsense_hid.ts
+++ b/src/hid/dualsense_hid.ts
@@ -5,6 +5,8 @@ import {
   DefaultDualsenseHIDState,
 } from "./hid_provider";
 import { computeBluetoothReportChecksum } from "./bt_checksum";
+import { FirmwareInfo, readFirmwareInfo } from "./firmware_info";
+import { FactoryInfo, readFactoryInfo } from "./factory_info";
 
 export type HIDCallback = (state: DualsenseHIDState) => void;
 export type ErrorCallback = (error: Error) => void;
@@ -32,6 +34,10 @@ export class DualsenseHID {
   private pendingCommands: CommandEvent[] = [];
   /** Most recent HID state of the device */
   public state: DualsenseHIDState = { ...DefaultDualsenseHIDState };
+  /** Firmware and hardware information, populated after connection */
+  public firmwareInfo?: FirmwareInfo;
+  /** Factory information (serial, color, board revision), populated after connection */
+  public factoryInfo?: FactoryInfo;
 
   constructor(
     readonly provider: HIDProvider,
@@ -88,6 +94,26 @@ export class DualsenseHID {
   /** Pass errors along to all error subscribers */
   private handleError(error: Error): void {
     this.errorSubscribers.forEach((callback) => callback(error));
+  }
+
+  /** Read firmware info from the controller (Feature Report 0x20) */
+  public async fetchFirmwareInfo(): Promise<FirmwareInfo | undefined> {
+    this.firmwareInfo = await readFirmwareInfo(this.provider);
+    return this.firmwareInfo;
+  }
+
+  /**
+   * Read factory info (serial number, body color, board revision) from the controller.
+   * Requires firmware info to be fetched first for feature gating.
+   */
+  public async fetchFactoryInfo(): Promise<FactoryInfo | undefined> {
+    if (!this.firmwareInfo) return undefined;
+    this.factoryInfo = await readFactoryInfo(
+      this.provider,
+      this.firmwareInfo.hardwareInfo,
+      this.firmwareInfo.mainFirmwareVersionRaw,
+    );
+    return this.factoryInfo;
   }
 
   /** Condense all pending commands into one HID feature report */

--- a/src/hid/dualsense_hid.ts
+++ b/src/hid/dualsense_hid.ts
@@ -7,6 +7,7 @@ import {
 import { computeBluetoothReportChecksum } from "./bt_checksum";
 import { FirmwareInfo, DefaultFirmwareInfo, readFirmwareInfo } from "./firmware_info";
 import { FactoryInfo, DefaultFactoryInfo, readFactoryInfo } from "./factory_info";
+import { readMacAddress } from "./pairing_info";
 
 export type HIDCallback = (state: DualsenseHIDState) => void;
 export type ErrorCallback = (error: Error) => void;
@@ -50,6 +51,8 @@ export class DualsenseHID {
   public firmwareInfo: FirmwareInfo = DefaultFirmwareInfo;
   /** Factory information (serial, color, board revision), populated after connection */
   public factoryInfo: FactoryInfo = DefaultFactoryInfo;
+  /** Bluetooth MAC address from Feature Report 0x09, populated after connection */
+  public macAddress?: string;
 
   constructor(
     readonly provider: HIDProvider,
@@ -147,12 +150,15 @@ export class DualsenseHID {
 
   /**
    * Stable hardware identity for this controller, derived from the most
-   * trustworthy info available. Prefers the factory serial (32-char ASCII
-   * stamped at the factory), then falls back to the firmware deviceInfo
-   * blob (12 hex bytes available on every transport on every platform).
-   * Returns undefined until firmware info has been read.
+   * trustworthy info available. Prefers the Bluetooth MAC address (from
+   * Feature Report 0x09, works on every transport and platform), then
+   * falls back to the factory serial, then firmware deviceInfo.
+   * Returns undefined until identity info has been read.
    */
   public get identity(): string | undefined {
+    if (this.macAddress) {
+      return `mac:${this.macAddress}`;
+    }
     if (this.factoryInfo.serialNumber !== DefaultFactoryInfo.serialNumber) {
       return `serial:${this.factoryInfo.serialNumber}`;
     }
@@ -201,6 +207,10 @@ export class DualsenseHID {
     this.identityRetryCount += 1;
 
     try {
+      // Read MAC address first — simple feature report, no firmware gate.
+      const mac = await readMacAddress(this.provider);
+      if (mac) this.macAddress = mac;
+
       // Always read fresh from the device (bypass the idempotency cache).
       const fw = await readFirmwareInfo(this.provider);
       if (fw) {

--- a/src/hid/factory_info.ts
+++ b/src/hid/factory_info.ts
@@ -1,28 +1,54 @@
 import { HIDProvider } from "./hid_provider";
 
+/** Known DualSense body colors */
+export enum DualsenseColor {
+  Unknown = "Unknown",
+  White = "White",
+  MidnightBlack = "Midnight Black",
+  CosmicRed = "Cosmic Red",
+  NovaPink = "Nova Pink",
+  GalacticPurple = "Galactic Purple",
+  StarlightBlue = "Starlight Blue",
+  GreyCamouflage = "Grey Camouflage",
+  VolcanicRed = "Volcanic Red",
+  SterlingSilver = "Sterling Silver",
+  CobaltBlue = "Cobalt Blue",
+  ChromaTeal = "Chroma Teal",
+  ChromaIndigo = "Chroma Indigo",
+  ChromaPearl = "Chroma Pearl",
+  Anniversary30th = "30th Anniversary",
+  GodOfWarRagnarok = "God of War Ragnarok",
+  SpiderMan2 = "Spider-Man 2",
+  AstroBot = "Astro Bot",
+  Fortnite = "Fortnite",
+  TheLastOfUs = "The Last of Us",
+  IconBlueLimitedEdition = "Icon Blue Limited Edition",
+  GenshinImpact = "Genshin Impact",
+}
+
 /** Known DualSense body colors, keyed by the 2-char code from the serial number */
-export const DualsenseColorMap: Record<string, string> = {
-  "00": "White",
-  "01": "Midnight Black",
-  "02": "Cosmic Red",
-  "03": "Nova Pink",
-  "04": "Galactic Purple",
-  "05": "Starlight Blue",
-  "06": "Grey Camouflage",
-  "07": "Volcanic Red",
-  "08": "Sterling Silver",
-  "09": "Cobalt Blue",
-  "10": "Chroma Teal",
-  "11": "Chroma Indigo",
-  "12": "Chroma Pearl",
-  "30": "30th Anniversary",
-  Z1: "God of War Ragnarok",
-  Z2: "Spider-Man 2",
-  Z3: "Astro Bot",
-  Z4: "Fortnite",
-  Z6: "The Last of Us",
-  ZB: "Icon Blue Limited Edition",
-  ZE: "Genshin Impact",
+export const DualsenseColorMap: Record<string, DualsenseColor> = {
+  "00": DualsenseColor.White,
+  "01": DualsenseColor.MidnightBlack,
+  "02": DualsenseColor.CosmicRed,
+  "03": DualsenseColor.NovaPink,
+  "04": DualsenseColor.GalacticPurple,
+  "05": DualsenseColor.StarlightBlue,
+  "06": DualsenseColor.GreyCamouflage,
+  "07": DualsenseColor.VolcanicRed,
+  "08": DualsenseColor.SterlingSilver,
+  "09": DualsenseColor.CobaltBlue,
+  "10": DualsenseColor.ChromaTeal,
+  "11": DualsenseColor.ChromaIndigo,
+  "12": DualsenseColor.ChromaPearl,
+  "30": DualsenseColor.Anniversary30th,
+  Z1: DualsenseColor.GodOfWarRagnarok,
+  Z2: DualsenseColor.SpiderMan2,
+  Z3: DualsenseColor.AstroBot,
+  Z4: DualsenseColor.Fortnite,
+  Z6: DualsenseColor.TheLastOfUs,
+  ZB: DualsenseColor.IconBlueLimitedEdition,
+  ZE: DualsenseColor.GenshinImpact,
 };
 
 /** Board revision names, keyed by the character at serial position 1 */
@@ -38,13 +64,21 @@ const BoardRevisionMap: Record<string, string> = {
 export interface FactoryInfo {
   /** Raw serial number string */
   serialNumber: string;
-  /** Controller body color name (e.g. "Cosmic Red"), or undefined if unknown */
-  colorName?: string;
+  /** Controller body color name (e.g. "Cosmic Red") */
+  colorName: string;
   /** Raw 2-character color code from the serial number */
   colorCode: string;
-  /** Board revision (e.g. "BDM-030"), or undefined if unknown */
-  boardRevision?: string;
+  /** Board revision (e.g. "BDM-030") */
+  boardRevision: string;
 }
+
+/** Default FactoryInfo used when the test command protocol is unavailable (e.g. Linux Bluetooth via node-hid) */
+export const DefaultFactoryInfo: FactoryInfo = {
+  serialNumber: "unknown",
+  colorName: "unknown",
+  colorCode: "??",
+  boardRevision: "unknown",
+};
 
 /** Feature report IDs for the test command protocol */
 const SEND_REPORT_ID = 0x80;
@@ -82,7 +116,10 @@ async function sendTestCommand(
   for (let i = 0; i < maxAttempts; i++) {
     await sleep(50);
 
-    const response = await provider.readFeatureReport(RECV_REPORT_ID, REPORT_SIZE);
+    const response = await provider.readFeatureReport(
+      RECV_REPORT_ID,
+      REPORT_SIZE,
+    );
     if (response.length === 0) continue;
 
     // Response layout: [reportId, deviceId, actionId, status, ...data]
@@ -138,7 +175,11 @@ export async function readFactoryInfo(
   }
 
   try {
-    const result = await sendTestCommand(provider, DEVICE_SYSTEM, ACTION_READ_SERIAL);
+    const result = await sendTestCommand(
+      provider,
+      DEVICE_SYSTEM,
+      ACTION_READ_SERIAL,
+    );
     if (!result) return undefined;
 
     const serialNumber = decodeAscii(result, 0, 32);
@@ -149,9 +190,9 @@ export async function readFactoryInfo(
 
     return {
       serialNumber,
-      colorName: DualsenseColorMap[colorCode],
+      colorName: DualsenseColorMap[colorCode] ?? colorCode,
       colorCode,
-      boardRevision: BoardRevisionMap[revisionChar],
+      boardRevision: BoardRevisionMap[revisionChar] ?? "unknown",
     };
   } catch {
     return undefined;

--- a/src/hid/factory_info.ts
+++ b/src/hid/factory_info.ts
@@ -1,0 +1,159 @@
+import { HIDProvider } from "./hid_provider";
+
+/** Known DualSense body colors, keyed by the 2-char code from the serial number */
+export const DualsenseColorMap: Record<string, string> = {
+  "00": "White",
+  "01": "Midnight Black",
+  "02": "Cosmic Red",
+  "03": "Nova Pink",
+  "04": "Galactic Purple",
+  "05": "Starlight Blue",
+  "06": "Grey Camouflage",
+  "07": "Volcanic Red",
+  "08": "Sterling Silver",
+  "09": "Cobalt Blue",
+  "10": "Chroma Teal",
+  "11": "Chroma Indigo",
+  "12": "Chroma Pearl",
+  "30": "30th Anniversary",
+  Z1: "God of War Ragnarok",
+  Z2: "Spider-Man 2",
+  Z3: "Astro Bot",
+  Z4: "Fortnite",
+  Z6: "The Last of Us",
+  ZB: "Icon Blue Limited Edition",
+  ZE: "Genshin Impact",
+};
+
+/** Board revision names, keyed by the character at serial position 1 */
+const BoardRevisionMap: Record<string, string> = {
+  "1": "BDM-010",
+  "2": "BDM-020",
+  "3": "BDM-030",
+  "4": "BDM-040",
+  "5": "BDM-050",
+};
+
+/** Factory information derived from the controller's serial number */
+export interface FactoryInfo {
+  /** Raw serial number string */
+  serialNumber: string;
+  /** Controller body color name (e.g. "Cosmic Red"), or undefined if unknown */
+  colorName?: string;
+  /** Raw 2-character color code from the serial number */
+  colorCode: string;
+  /** Board revision (e.g. "BDM-030"), or undefined if unknown */
+  boardRevision?: string;
+}
+
+/** Feature report IDs for the test command protocol */
+const SEND_REPORT_ID = 0x80;
+const RECV_REPORT_ID = 0x81;
+/** Report size for test command feature reports (report ID + 63 bytes payload) */
+const REPORT_SIZE = 64;
+
+/** Test command device/action IDs */
+const DEVICE_SYSTEM = 0x01;
+const ACTION_READ_SERIAL = 0x13;
+
+/** Test command response status values */
+const STATUS_COMPLETE = 0x02;
+
+/**
+ * Send a test command via Feature Report 0x80 and poll 0x81 for the response.
+ * Returns the result data bytes (after the header), or undefined on failure.
+ */
+async function sendTestCommand(
+  provider: HIDProvider,
+  deviceId: number,
+  actionId: number,
+  maxAttempts: number = 20,
+): Promise<Uint8Array | undefined> {
+  // Build the send report: report ID at byte 0, then payload.
+  // The provider handles platform differences (WebHID strips byte 0, adds CRC for BT).
+  const sendBuf = new Uint8Array(REPORT_SIZE).fill(0);
+  sendBuf[0] = SEND_REPORT_ID;
+  sendBuf[1] = deviceId;
+  sendBuf[2] = actionId;
+
+  await provider.sendFeatureReport(SEND_REPORT_ID, sendBuf);
+
+  // Poll for response
+  for (let i = 0; i < maxAttempts; i++) {
+    await sleep(50);
+
+    const response = await provider.readFeatureReport(RECV_REPORT_ID, REPORT_SIZE);
+    if (response.length === 0) continue;
+
+    // Response layout: [reportId, deviceId, actionId, status, ...data]
+    // Note: node-hid includes the report ID at byte 0; WebHID may not.
+    // Find the actual start based on whether byte 0 is the report ID.
+    const offset = response[0] === RECV_REPORT_ID ? 1 : 0;
+    const respDevice = response[offset];
+    const respAction = response[offset + 1];
+    const respStatus = response[offset + 2];
+
+    if (respDevice !== deviceId || respAction !== actionId) continue;
+    if (respStatus === STATUS_COMPLETE) {
+      return response.slice(offset + 3);
+    }
+  }
+
+  return undefined;
+}
+
+/** Decode a byte array as ASCII, stopping at null terminator */
+function decodeAscii(data: Uint8Array, offset: number, length: number): string {
+  let str = "";
+  for (let i = 0; i < length; i++) {
+    const byte = data[offset + i];
+    if (byte === 0) break;
+    str += String.fromCharCode(byte);
+  }
+  return str;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Read factory info (serial number, body color, board revision) from a connected controller.
+ *
+ * Requires firmware support: hardwareInfo >= 777 and mainFirmwareVersion >= 65655.
+ * Use the values from FirmwareInfo (Feature Report 0x20) to check this gate.
+ *
+ * @param provider The HID provider for the connected controller
+ * @param hardwareInfo Hardware info word from FirmwareInfo
+ * @param mainFwVersionRaw Raw uint32 main firmware version from FirmwareInfo
+ */
+export async function readFactoryInfo(
+  provider: HIDProvider,
+  hardwareInfo: number,
+  mainFwVersionRaw: number,
+): Promise<FactoryInfo | undefined> {
+  // Firmware gate check
+  if ((hardwareInfo & 0xffff) < 777 || mainFwVersionRaw < 65655) {
+    return undefined;
+  }
+
+  try {
+    const result = await sendTestCommand(provider, DEVICE_SYSTEM, ACTION_READ_SERIAL);
+    if (!result) return undefined;
+
+    const serialNumber = decodeAscii(result, 0, 32);
+    if (serialNumber.length < 6) return undefined;
+
+    const colorCode = serialNumber.slice(4, 6);
+    const revisionChar = serialNumber.slice(1, 2);
+
+    return {
+      serialNumber,
+      colorName: DualsenseColorMap[colorCode],
+      colorCode,
+      boardRevision: BoardRevisionMap[revisionChar],
+    };
+  } catch {
+    return undefined;
+  }
+}

--- a/src/hid/factory_info.ts
+++ b/src/hid/factory_info.ts
@@ -187,12 +187,18 @@ export async function readFactoryInfo(
 
     const colorCode = serialNumber.slice(4, 6);
     const revisionChar = serialNumber.slice(1, 2);
+    const colorName =
+      colorCode in DualsenseColorMap ? DualsenseColorMap[colorCode] : colorCode;
+    const boardRevision =
+      revisionChar in BoardRevisionMap
+        ? BoardRevisionMap[revisionChar]
+        : "unknown";
 
     return {
       serialNumber,
-      colorName: DualsenseColorMap[colorCode] ?? colorCode,
+      colorName,
       colorCode,
-      boardRevision: BoardRevisionMap[revisionChar] ?? "unknown",
+      boardRevision,
     };
   } catch {
     return undefined;

--- a/src/hid/firmware_info.ts
+++ b/src/hid/firmware_info.ts
@@ -37,6 +37,26 @@ export interface FirmwareInfo {
   spiderDspFirmwareVersion: FirmwareVersion;
 }
 
+/** A zeroed firmware version */
+const UnknownVersion: FirmwareVersion = { major: 0, minor: 0, patch: 0 };
+
+/** Default FirmwareInfo used when Feature Report 0x20 could not be read */
+export const DefaultFirmwareInfo: FirmwareInfo = {
+  buildDate: "unknown",
+  buildTime: "unknown",
+  firmwareType: 0,
+  softwareSeries: 0,
+  hardwareInfo: 0,
+  mainFirmwareVersion: UnknownVersion,
+  mainFirmwareVersionRaw: 0,
+  deviceInfo: "unknown",
+  updateVersion: "00.00",
+  updateImageInfo: 0,
+  sblFirmwareVersion: UnknownVersion,
+  dspFirmwareVersion: "0000_0000",
+  spiderDspFirmwareVersion: UnknownVersion,
+};
+
 /** Format a FirmwareVersion as "major.minor.patch" */
 export function formatFirmwareVersion(v: FirmwareVersion): string {
   return `${v.major}.${v.minor}.${v.patch}`;

--- a/src/hid/firmware_info.ts
+++ b/src/hid/firmware_info.ts
@@ -1,0 +1,137 @@
+import { HIDProvider } from "./hid_provider";
+
+/** Parsed firmware version in major.minor.patch format */
+export interface FirmwareVersion {
+  major: number;
+  minor: number;
+  patch: number;
+}
+
+/** Firmware and hardware information from Feature Report 0x20 */
+export interface FirmwareInfo {
+  /** Firmware build date (e.g. "Apr 14 2023") */
+  buildDate: string;
+  /** Firmware build time (e.g. "12:34:56") */
+  buildTime: string;
+  /** Firmware type (2 or 3 indicates production firmware) */
+  firmwareType: number;
+  /** Software series identifier */
+  softwareSeries: number;
+  /** Hardware info word (lower 16 bits used for feature gating) */
+  hardwareInfo: number;
+  /** Main firmware version */
+  mainFirmwareVersion: FirmwareVersion;
+  /** Raw uint32 main firmware version (used for feature gating) */
+  mainFirmwareVersionRaw: number;
+  /** Device info (raw hex string) */
+  deviceInfo: string;
+  /** Update version (formatted as HH.LL hex) */
+  updateVersion: string;
+  /** Update image info */
+  updateImageInfo: number;
+  /** SBL (second bootloader) firmware version */
+  sblFirmwareVersion: FirmwareVersion;
+  /** DSP firmware version (formatted as HHHH_LLLL hex) */
+  dspFirmwareVersion: string;
+  /** Spider DSP firmware version */
+  spiderDspFirmwareVersion: FirmwareVersion;
+}
+
+/** Format a FirmwareVersion as "major.minor.patch" */
+export function formatFirmwareVersion(v: FirmwareVersion): string {
+  return `${v.major}.${v.minor}.${v.patch}`;
+}
+
+/** Feature report ID for firmware information */
+const REPORT_ID = 0x20;
+/** Expected report length (report ID + 63 bytes of data) */
+const REPORT_LENGTH = 64;
+
+/** Parse a uint32 version into major.minor.patch */
+function parseVersion(ver: number): FirmwareVersion {
+  return {
+    major: (ver >>> 24) & 0xff,
+    minor: (ver >>> 16) & 0xff,
+    patch: ver & 0xffff,
+  };
+}
+
+/** Format a uint16 as HH.LL hex */
+function formatUpdateVersion(ver: number): string {
+  const hi = ((ver >>> 8) & 0xff).toString(16).padStart(2, "0");
+  const lo = (ver & 0xff).toString(16).padStart(2, "0");
+  return `${hi}.${lo}`;
+}
+
+/** Format a uint32 as HHHH_LLLL hex */
+function formatDspVersion(ver: number): string {
+  const hi = ((ver >>> 16) & 0xffff).toString(16).padStart(4, "0");
+  const lo = (ver & 0xffff).toString(16).padStart(4, "0");
+  return `${hi}_${lo}`;
+}
+
+/** Read a null-terminated ASCII string from a buffer */
+function readString(data: Uint8Array, offset: number, length: number): string {
+  let str = "";
+  for (let i = 0; i < length; i++) {
+    const byte = data[offset + i];
+    if (byte === 0) break;
+    str += String.fromCharCode(byte);
+  }
+  return str;
+}
+
+/** Read a little-endian uint16 from a buffer */
+function readUint16LE(data: Uint8Array, offset: number): number {
+  return data[offset] | (data[offset + 1] << 8);
+}
+
+/** Read a little-endian uint32 from a buffer */
+function readUint32LE(data: Uint8Array, offset: number): number {
+  return (
+    data[offset] |
+    (data[offset + 1] << 8) |
+    (data[offset + 2] << 16) |
+    ((data[offset + 3] << 24) >>> 0)
+  );
+}
+
+/** Convert bytes to a hex string */
+function toHex(data: Uint8Array, offset: number, length: number): string {
+  return Array.from(data.slice(offset, offset + length))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+/**
+ * Read and parse Feature Report 0x20 from a connected controller.
+ * Returns undefined if the report cannot be read.
+ */
+export async function readFirmwareInfo(
+  provider: HIDProvider,
+): Promise<FirmwareInfo | undefined> {
+  try {
+    const data = await provider.readFeatureReport(REPORT_ID, REPORT_LENGTH);
+
+    // Offsets are from byte 1 (after the report ID byte)
+    const base = 1;
+
+    return {
+      buildDate: readString(data, base, 11),
+      buildTime: readString(data, base + 11, 8),
+      firmwareType: readUint16LE(data, base + 19),
+      softwareSeries: readUint16LE(data, base + 21),
+      hardwareInfo: readUint32LE(data, base + 23),
+      mainFirmwareVersion: parseVersion(readUint32LE(data, base + 27)),
+      mainFirmwareVersionRaw: readUint32LE(data, base + 27),
+      deviceInfo: toHex(data, base + 31, 12),
+      updateVersion: formatUpdateVersion(readUint16LE(data, base + 43)),
+      updateImageInfo: data[base + 45],
+      sblFirmwareVersion: parseVersion(readUint32LE(data, base + 47)),
+      dspFirmwareVersion: formatDspVersion(readUint32LE(data, base + 51)),
+      spiderDspFirmwareVersion: parseVersion(readUint32LE(data, base + 55)),
+    };
+  } catch {
+    return undefined;
+  }
+}

--- a/src/hid/hid_provider.ts
+++ b/src/hid/hid_provider.ts
@@ -190,6 +190,12 @@ export abstract class HIDProvider {
   /** Write to the HID device */
   abstract write(data: Uint8Array): Promise<void>;
 
+  /** Read a feature report from the device */
+  abstract readFeatureReport(reportId: number, length?: number): Promise<Uint8Array>;
+
+  /** Send a feature report to the device */
+  abstract sendFeatureReport(reportId: number, data: Uint8Array): Promise<void>;
+
   /** If true, gyroscope, touchpad, accelerometer are disabled */
   public limited?: boolean;
 

--- a/src/hid/hid_provider.ts
+++ b/src/hid/hid_provider.ts
@@ -160,6 +160,12 @@ export abstract class HIDProvider {
   /** Callback to use for Error events */
   public onError: (error: Error) => void = () => {};
 
+  /** Callback fired the moment a device is fully attached and ready for I/O */
+  public onConnect: () => void = () => {};
+
+  /** Callback fired the moment a device detaches (cleanly or via error) */
+  public onDisconnect: () => void = () => {};
+
   /** Unique identifier for the connected device (path or serial) */
   public deviceId?: string;
 
@@ -227,6 +233,7 @@ export abstract class HIDProvider {
    * Reset the HIDProvider state when the device is disconnected
    */
   protected reset(): void {
+    const wasAttached = this.device !== undefined;
     if (this.deviceId) {
       HIDProvider.claimedDevices.delete(this.deviceId);
     }
@@ -237,6 +244,7 @@ export abstract class HIDProvider {
     this.deviceId = undefined;
     this.serialNumber = undefined;
     this.onData(DefaultDualsenseHIDState);
+    if (wasAttached) this.onDisconnect();
   }
 
   /**

--- a/src/hid/index.ts
+++ b/src/hid/index.ts
@@ -11,5 +11,6 @@ export * from "./factory_info";
 export * from "./firmware_info";
 export * from "./hid_provider";
 export * from "./node_hid_provider";
+export * from "./pairing_info";
 export * from "./platform_hid_provider";
 export * from "./web_hid_provider";

--- a/src/hid/index.ts
+++ b/src/hid/index.ts
@@ -7,6 +7,8 @@ export * from "./bt_checksum";
 export * from "./byte_array";
 export * from "./command";
 export * from "./dualsense_hid";
+export * from "./factory_info";
+export * from "./firmware_info";
 export * from "./hid_provider";
 export * from "./node_hid_provider";
 export * from "./platform_hid_provider";

--- a/src/hid/node_hid_provider.ts
+++ b/src/hid/node_hid_provider.ts
@@ -148,6 +148,19 @@ export class NodeHIDProvider extends HIDProvider {
     return Promise.resolve();
   }
 
+  readFeatureReport(reportId: number, length: number): Promise<Uint8Array> {
+    if (!this.device) return Promise.reject(new Error("No device connected"));
+    const buf = this.device.getFeatureReport(reportId, length);
+    return Promise.resolve(new Uint8Array(buf));
+  }
+
+  sendFeatureReport(_reportId: number, data: Uint8Array): Promise<void> {
+    if (!this.device) return Promise.resolve();
+    // node-hid sendFeatureReport expects the report ID as the first byte of the buffer
+    this.device.sendFeatureReport(Array.from(data));
+    return Promise.resolve();
+  }
+
   get connected(): boolean {
     return this.device !== undefined;
   }

--- a/src/hid/node_hid_provider.ts
+++ b/src/hid/node_hid_provider.ts
@@ -133,6 +133,7 @@ export class NodeHIDProvider extends HIDProvider {
       });
 
       this.device = device;
+      this.onConnect();
     } catch (err) {
       this.onError(
         err instanceof Error ? err : new Error(String(err))

--- a/src/hid/pairing_info.ts
+++ b/src/hid/pairing_info.ts
@@ -1,0 +1,33 @@
+import { HIDProvider } from "./hid_provider";
+
+/** Feature report ID for pairing info */
+const REPORT_ID = 0x09;
+/** Expected report length (report ID + 19 bytes) */
+const REPORT_LENGTH = 20;
+
+/**
+ * Read the controller's Bluetooth MAC address from Feature Report 0x09.
+ * Works over both USB and Bluetooth on all platforms.
+ * Returns the MAC as a colon-separated hex string (e.g. "AA:BB:CC:DD:EE:FF"),
+ * or undefined if the report cannot be read.
+ */
+export async function readMacAddress(
+  provider: HIDProvider,
+): Promise<string | undefined> {
+  try {
+    const data = await provider.readFeatureReport(REPORT_ID, REPORT_LENGTH);
+
+    // Bytes 1–6 contain the MAC in little-endian order
+    const mac: string[] = [];
+    for (let i = 6; i >= 1; i--) {
+      mac.push(data[i].toString(16).padStart(2, "0"));
+    }
+
+    const result = mac.join(":");
+    // Reject all-zero MACs (no pairing info available)
+    if (result === "00:00:00:00:00:00") return undefined;
+    return result;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/hid/web_hid_provider.ts
+++ b/src/hid/web_hid_provider.ts
@@ -82,7 +82,7 @@ export class WebHIDProvider extends HIDProvider {
   }
 
   /** Derive a stable identity string for a WebHID device */
-  private static deviceKey(device: HIDDevice): string {
+  static deviceKey(device: HIDDevice): string {
     // WebHID does not expose serial numbers or paths directly.
     // We use the product name + vendor/product ids as a coarse key, but
     // because multiple identical controllers may be connected, append the
@@ -95,16 +95,12 @@ export class WebHIDProvider extends HIDProvider {
 
   attach(device: HIDDevice): void {
     const key = WebHIDProvider.deviceKey(device);
-    if (HIDProvider.claimedDevices.has(key)) {
-      return; // Already claimed by another instance
-    }
 
-    device
-      .open()
+    const openPromise = device.opened ? Promise.resolve() : device.open();
+    openPromise
       .then(() => {
         this.device = device;
         this.deviceId = key;
-        HIDProvider.claimedDevices.add(key);
         this.detectConnectionType();
 
         // Enable accelerometer, gyro, touchpad
@@ -116,9 +112,11 @@ export class WebHIDProvider extends HIDProvider {
           this.buffer = data;
           this.onData(this.process({ reportId, buffer: data }));
         });
+        console.log("[WebHID] attach: firing onConnect");
         this.onConnect();
       })
       .catch((err: Error) => {
+        console.log("[WebHID] attach: error", err.message);
         this.onError(err);
         this.disconnect();
       });
@@ -225,7 +223,13 @@ export class WebHIDProvider extends HIDProvider {
 
   disconnect(): void {
     if (this.device) {
-      this.device.close().finally(() => this.reset());
+      const dev = this.device;
+      // Reset synchronously so claimedDevices is freed immediately —
+      // otherwise a rapid disconnect/reconnect can race: the browser's
+      // connect event arrives before close() resolves, and attach() sees
+      // the key still claimed and silently bails out.
+      this.reset();
+      dev.close().catch(() => {});
     } else {
       this.reset();
     }

--- a/src/hid/web_hid_provider.ts
+++ b/src/hid/web_hid_provider.ts
@@ -1,5 +1,6 @@
 import { ByteArray } from "./byte_array";
 import { HIDProvider, DualsenseHIDState } from "./hid_provider";
+import { computeFeatureReportChecksum } from "./bt_checksum";
 
 export interface WebHIDProviderOptions {
   /** Attach to this specific HIDDevice instead of discovering one */
@@ -203,6 +204,57 @@ export class WebHIDProvider extends HIDProvider {
     } else {
       this.reset();
     }
+  }
+
+  async readFeatureReport(reportId: number): Promise<Uint8Array> {
+    if (!this.device) throw new Error("No device connected");
+    const view = await this.device.receiveFeatureReport(reportId);
+    return new Uint8Array(view.buffer, view.byteOffset, view.byteLength);
+  }
+
+  async sendFeatureReport(reportId: number, data: Uint8Array): Promise<void> {
+    if (!this.device) return;
+
+    // WebHID sendFeatureReport takes the report ID separately.
+    // data[0] is the report ID (for node-hid compat); strip it for WebHID.
+    const rawPayload = data.slice(1);
+
+    // Pad to the expected payload length from the HID descriptor
+    const expectedLength = this.getFeatureReportLength(reportId);
+    const payload = expectedLength > 0 && rawPayload.length < expectedLength
+      ? new Uint8Array(expectedLength)
+      : new Uint8Array(rawPayload);
+
+    if (expectedLength > rawPayload.length) {
+      payload.set(rawPayload);
+    }
+
+    // Bluetooth requires CRC-32 in the last 4 bytes of the payload
+    if (this.wireless) {
+      const crc = computeFeatureReportChecksum(reportId, payload);
+      const off = payload.length - 4;
+      payload[off] = crc & 0xff;
+      payload[off + 1] = (crc >>> 8) & 0xff;
+      payload[off + 2] = (crc >>> 16) & 0xff;
+      payload[off + 3] = (crc >>> 24) & 0xff;
+    }
+
+    await this.device.sendFeatureReport(reportId, payload);
+  }
+
+  /** Query the HID descriptor for the expected payload length of a feature report */
+  private getFeatureReportLength(reportId: number): number {
+    if (!this.device) return 0;
+    for (const c of this.device.collections) {
+      const report = (c.featureReports ?? []).find((r) => r.reportId === reportId);
+      if (report) {
+        return (report.items ?? []).reduce(
+          (sum, item) => sum + Math.ceil(((item.reportSize ?? 0) * (item.reportCount ?? 0)) / 8),
+          0,
+        );
+      }
+    }
+    return 0;
   }
 
   async write(data: Uint8Array): Promise<void> {

--- a/src/hid/web_hid_provider.ts
+++ b/src/hid/web_hid_provider.ts
@@ -26,7 +26,8 @@ export class WebHIDProvider extends HIDProvider {
 
     navigator.hid.addEventListener("disconnect", ({ device }) => {
       if (device === this.device) {
-        this.device = undefined;
+        // Let disconnect() → reset() handle nulling this.device so that
+        // reset() can detect the device was attached and fire onDisconnect.
         this.disconnect();
       }
     });
@@ -115,11 +116,35 @@ export class WebHIDProvider extends HIDProvider {
           this.buffer = data;
           this.onData(this.process({ reportId, buffer: data }));
         });
+        this.onConnect();
       })
       .catch((err: Error) => {
         this.onError(err);
         this.disconnect();
       });
+  }
+
+  /**
+   * Detach the current HIDDevice (if any) and attach a different one in place.
+   * Used by the manager to transplant a freshly-discovered device into an
+   * existing slot's provider after identity matching, so the consumer's
+   * Dualsense reference survives reconnection.
+   *
+   * The new device must already be open (or openable) — we close the old one,
+   * release its claim, and run the standard attach() flow on the new one.
+   */
+  replaceDevice(device: HIDDevice): void {
+    // Tear down the existing device without firing the disconnect cascade
+    // (we don't want subscribers to see a disconnect/reconnect blip).
+    if (this.device) {
+      const old = this.device;
+      const oldKey = this.deviceId;
+      this.device = undefined;
+      if (oldKey) HIDProvider.claimedDevices.delete(oldKey);
+      // Best-effort close; failures are non-fatal.
+      old.close().catch(() => {});
+    }
+    this.attach(device);
   }
 
   /**

--- a/src/hid/web_hid_provider.ts
+++ b/src/hid/web_hid_provider.ts
@@ -82,7 +82,7 @@ export class WebHIDProvider extends HIDProvider {
   }
 
   /** Derive a stable identity string for a WebHID device */
-  static deviceKey(device: HIDDevice): string {
+  private static deviceKey(device: HIDDevice): string {
     // WebHID does not expose serial numbers or paths directly.
     // We use the product name + vendor/product ids as a coarse key, but
     // because multiple identical controllers may be connected, append the
@@ -112,11 +112,9 @@ export class WebHIDProvider extends HIDProvider {
           this.buffer = data;
           this.onData(this.process({ reportId, buffer: data }));
         });
-        console.log("[WebHID] attach: firing onConnect");
         this.onConnect();
       })
       .catch((err: Error) => {
-        console.log("[WebHID] attach: error", err.message);
         this.onError(err);
         this.disconnect();
       });

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -321,10 +321,8 @@ export class DualsenseManager extends Input<DualsenseManagerState> {
       players.size === this.lastPlayerCount &&
       key === this.lastPlayerKey
     ) {
-      console.log("[Manager] updateState dedup — skipping", key);
       return;
     }
-    console.log("[Manager] updateState publishing", { activeCount, playerCount: players.size, key });
     this.lastActive = activeCount;
     this.lastPlayerCount = players.size;
     this.lastPlayerKey = key;
@@ -405,7 +403,6 @@ export class DualsenseManager extends Input<DualsenseManagerState> {
    * the consumer's Dualsense reference is preserved across reconnect.
    */
   private handleSlotReady(slot: ControllerSlot): void {
-    console.log("[Manager] handleSlotReady", { index: slot.index, identity: slot.controller.hid.identity, provisional: slot.provisional });
     const identity = slot.controller.hid.identity;
 
     // No identity at all (firmware read failed completely after retries) —
@@ -454,7 +451,6 @@ export class DualsenseManager extends Input<DualsenseManagerState> {
     // Existing slot is disconnected — transplant the new device into it.
     // The new (provisional) slot is dropped before any state is published,
     // so the consumer only ever sees the original slot reconnect in place.
-    console.log("[Manager] transplanting slot", slot.index, "→", existingSlot.index);
     this.transplant(slot, existingSlot);
   }
 
@@ -588,7 +584,6 @@ export class DualsenseManager extends Input<DualsenseManagerState> {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (typeof navigator !== "undefined" && navigator.hid) {
       navigator.hid.addEventListener("connect", ({ device }) => {
-        console.log("[Manager] navigator.hid connect event", device.productName);
         this.addWebDevice(device);
       });
 

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -321,8 +321,10 @@ export class DualsenseManager extends Input<DualsenseManagerState> {
       players.size === this.lastPlayerCount &&
       key === this.lastPlayerKey
     ) {
+      console.log("[Manager] updateState dedup — skipping", key);
       return;
     }
+    console.log("[Manager] updateState publishing", { activeCount, playerCount: players.size, key });
     this.lastActive = activeCount;
     this.lastPlayerCount = players.size;
     this.lastPlayerKey = key;
@@ -403,6 +405,7 @@ export class DualsenseManager extends Input<DualsenseManagerState> {
    * the consumer's Dualsense reference is preserved across reconnect.
    */
   private handleSlotReady(slot: ControllerSlot): void {
+    console.log("[Manager] handleSlotReady", { index: slot.index, identity: slot.controller.hid.identity, provisional: slot.provisional });
     const identity = slot.controller.hid.identity;
 
     // No identity at all (firmware read failed completely after retries) —
@@ -451,6 +454,7 @@ export class DualsenseManager extends Input<DualsenseManagerState> {
     // Existing slot is disconnected — transplant the new device into it.
     // The new (provisional) slot is dropped before any state is published,
     // so the consumer only ever sees the original slot reconnect in place.
+    console.log("[Manager] transplanting slot", slot.index, "→", existingSlot.index);
     this.transplant(slot, existingSlot);
   }
 
@@ -581,24 +585,35 @@ export class DualsenseManager extends Input<DualsenseManagerState> {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (typeof navigator !== "undefined" && navigator.hid) {
       navigator.hid.addEventListener("connect", ({ device }) => {
+        console.log("[Manager] navigator.hid connect event", device.productName);
         this.addWebDevice(device);
       });
 
-      // Enumerate already-permitted devices
-      void WebHIDProvider.enumerate().then((devices) => {
-        for (const device of devices) {
-          this.addWebDevice(device);
-        }
-      });
+      // Poll for permitted devices. The WebHID connect event only fires
+      // for newly-permitted devices, not for already-permitted devices
+      // that physically reconnect. Periodic enumeration catches those.
+      const poll = () => {
+        void WebHIDProvider.enumerate().then((devices) => {
+          for (const device of devices) {
+            this.addWebDevice(device);
+          }
+        });
+      };
+      poll();
+      this.discoveryTimer = setInterval(poll, 2000);
     }
   }
 
+  /** HIDDevice objects we've already handed to a provider */
+  private readonly knownWebDevices = new WeakSet<HIDDevice>();
+
   private addWebDevice(device: HIDDevice): void {
-    // Check if any existing slot's provider already has this device
-    for (const slot of this.slots) {
-      const provider = slot.controller.hid.provider as WebHIDProvider;
-      if (provider.device === device) return; // Already managed
-    }
+    // WeakSet tracks object identity — enumerate() returns the same objects
+    // for still-connected devices, so this deduplicates across polls.
+    // On reconnect, the browser provides a fresh HIDDevice object, so it
+    // passes this check and creates a new provisional slot.
+    if (this.knownWebDevices.has(device)) return;
+    this.knownWebDevices.add(device);
 
     const provider = new WebHIDProvider({ device });
     this.createSlot(provider, undefined, undefined);

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -367,10 +367,10 @@ export class DualsenseManager extends Input<DualsenseManagerState> {
       this.serialToSlot.set(serial, index);
     }
 
-    // Assign player LEDs — set immediately and re-apply on every connect,
-    // since the controller may not be connected yet at slot creation time.
+    // Assign player LEDs — skip for provisional slots (they may get
+    // transplanted to a different index). Re-apply on every connect.
     const applyPlayerLeds = () => {
-      if (this.autoAssignPlayerLeds) {
+      if (this.autoAssignPlayerLeds && !slot.provisional) {
         controller.playerLeds.set(this.playerPatterns[slot.index] ?? 0);
       }
     };
@@ -462,6 +462,9 @@ export class DualsenseManager extends Input<DualsenseManagerState> {
   private promoteSlot(slot: ControllerSlot): void {
     if (!slot.provisional) return;
     slot.provisional = false;
+    if (this.autoAssignPlayerLeds) {
+      slot.controller.playerLeds.set(this.playerPatterns[slot.index] ?? 0);
+    }
     this.updateState();
   }
 

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -10,12 +10,28 @@ import { WebHIDProvider } from "./hid/web_hid_provider";
 interface ControllerSlot {
   /** The Dualsense instance for this slot */
   controller: Dualsense;
-  /** Serial number for reconnection matching (Node.js only) */
+  /**
+   * Stable hardware identity, derived from firmware info once available.
+   * Format: "serial:..." (factory serial) or "device:..." (firmware deviceInfo blob).
+   * Preferred over node-hid's serial number, which is unreliable on Linux Bluetooth.
+   */
+  identity?: string;
+  /** Best-effort serial number from node-hid (may be wrong/missing) */
   serial?: string;
-  /** Current device path */
+  /** Current device path (Node.js) */
   path?: string;
   /** Slot index (stable, never reused until released) */
   index: number;
+  /** Set after we've subscribed to onReady, to avoid double-wiring */
+  readyHooked?: boolean;
+  /**
+   * True until firmware/factory info has loaded for the first time.
+   * Provisional slots are hidden from public state (`controllers`,
+   * `count`, `state.players`) so consumers don't see a connect that
+   * might immediately get merged into an existing slot via identity
+   * matching. Made non-provisional in `handleSlotReady`.
+   */
+  provisional?: boolean;
 }
 
 /** The state exposed by a DualsenseManager via the Input system */
@@ -100,8 +116,11 @@ export class DualsenseManager extends Input<DualsenseManagerState> {
   /** All controller slots, indexed by slot number */
   private readonly slots: ControllerSlot[] = [];
 
-  /** Map from serial number to slot index, for reconnection matching */
+  /** Map from node-hid serial to slot index — best-effort, used as a fallback */
   private readonly serialToSlot = new Map<string, number>();
+
+  /** Map from canonical hardware identity to slot index — preferred when available */
+  private readonly identityToSlot = new Map<string, number>();
 
   /** Discovery polling timer (Node.js only) */
   private discoveryTimer?: ReturnType<typeof setInterval>;
@@ -129,24 +148,45 @@ export class DualsenseManager extends Input<DualsenseManagerState> {
     return this.state.active > 0;
   }
 
-  /** All managed controller instances (including disconnected ones awaiting reconnection) */
+  /**
+   * All managed controller instances (including disconnected ones awaiting
+   * reconnection). Excludes provisional slots whose identity is still being
+   * resolved — those become visible only after firmware info loads, to
+   * avoid surfacing controllers that may be merged into an existing slot.
+   */
   public get controllers(): readonly Dualsense[] {
-    return this.slots.map((s) => s.controller);
+    return this.publicSlots().map((s) => s.controller);
   }
 
   /** Number of managed controllers (including disconnected ones awaiting reconnection) */
   public get count(): number {
-    return this.slots.length;
+    return this.publicSlots().length;
   }
 
   /** Get a controller by slot index */
   public get(index: number): Dualsense | undefined {
-    return this.slots[index]?.controller;
+    const slot = this.slots[index] as ControllerSlot | undefined;
+    if (!slot || slot.provisional) return undefined;
+    return slot.controller;
   }
 
   /** Iterate over all managed controllers */
   [Symbol.iterator](): IterableIterator<Dualsense> {
-    return this.slots.map((s) => s.controller).values();
+    return this.publicSlots().map((s) => s.controller).values();
+  }
+
+  /** Slots that are visible to the consumer (i.e. identity has been resolved) */
+  private publicSlots(): ControllerSlot[] {
+    return this.slots.filter((s) => !s.provisional);
+  }
+
+  /**
+   * True while at least one controller has been discovered but is still
+   * waiting for firmware info to load. Useful for showing a "connecting"
+   * state in the UI without surfacing the unresolved slot itself.
+   */
+  public get pending(): boolean {
+    return this.slots.some((s) => s.provisional);
   }
 
   /**
@@ -181,7 +221,10 @@ export class DualsenseManager extends Input<DualsenseManagerState> {
     // Disconnect the HID provider and release the claimed device
     slot.controller.hid.provider.disconnect();
 
-    // Remove serial mapping
+    // Remove identity / serial mappings
+    if (slot.identity) {
+      this.identityToSlot.delete(slot.identity);
+    }
     if (slot.serial) {
       this.serialToSlot.delete(slot.serial);
     }
@@ -189,10 +232,13 @@ export class DualsenseManager extends Input<DualsenseManagerState> {
     // Remove the slot (shift remaining slots down)
     this.slots.splice(index, 1);
 
-    // Re-index serial mappings after splice
+    // Re-index identity / serial mappings after splice
     for (let i = index; i < this.slots.length; i++) {
       const s = this.slots[i];
       s.index = i;
+      if (s.identity) {
+        this.identityToSlot.set(s.identity, i);
+      }
       if (s.serial) {
         this.serialToSlot.set(s.serial, i);
       }
@@ -249,54 +295,70 @@ export class DualsenseManager extends Input<DualsenseManagerState> {
 
   // --- Private ---
 
+  /** Previous state snapshot, for deduplication */
+  private lastActive = 0;
+  private lastPlayerCount = 0;
+  /** Fingerprint of the last published player set (slot indices + connected flags) */
+  private lastPlayerKey = "";
+
   /** Build a new state snapshot and push it through InputSet */
   private updateState(): void {
     const players = new Map<number, Dualsense>();
+    let activeCount = 0;
+    let key = "";
     for (const slot of this.slots) {
+      if (slot.provisional) continue;
       players.set(slot.index, slot.controller);
+      const connected = slot.controller.connection.active;
+      if (connected) activeCount += 1;
+      key += `${slot.index}:${connected ? "1" : "0"},`;
     }
 
-    const activeCount = this.slots.filter(
-      (s) => s.controller.connection.active
-    ).length;
+    // Suppress no-op publishes (e.g. provisional slots churning without
+    // changing the visible state) to avoid noisy change events.
+    if (
+      activeCount === this.lastActive &&
+      players.size === this.lastPlayerCount &&
+      key === this.lastPlayerKey
+    ) {
+      return;
+    }
+    this.lastActive = activeCount;
+    this.lastPlayerCount = players.size;
+    this.lastPlayerKey = key;
 
-    // Always creates a new object so BasicComparator detects the change
     this[InputSet]({ active: activeCount, players });
   }
 
-  /** Create a Dualsense instance and register it in a slot */
+  /**
+   * Create a Dualsense instance and register it in a (provisional) slot.
+   * The caller is responsible for opening the device on the provider — the
+   * manager treats this as the *only* path that opens new devices, so
+   * identity matching can run before the slot becomes visible.
+   *
+   * Note: identity is the sole reconnection key. We do NOT key on node-hid's
+   * serialNumber because it's frequently missing or wrong (especially over
+   * Bluetooth on Linux). Path is tracked only so we can re-target the same
+   * device on transplant.
+   */
   private createSlot(
     provider: HIDProvider,
     serial?: string,
     path?: string
   ): ControllerSlot {
-    // Check if this serial already has a slot (reconnection)
-    if (serial) {
-      const existingIndex = this.serialToSlot.get(serial);
-      if (existingIndex !== undefined) {
-        const existingSlot =
-          this.slots[existingIndex] as ControllerSlot | undefined;
-        if (existingSlot && !existingSlot.controller.connection.active) {
-          // Reconnect to existing slot: update the provider target
-          if (provider instanceof NodeHIDProvider) {
-            const existingProvider = existingSlot.controller.hid
-              .provider as NodeHIDProvider;
-            existingProvider.targetPath = path;
-            existingProvider.targetSerial = serial;
-          }
-          existingSlot.path = path;
-          // Release the new provider since we're reusing the existing one
-          provider.disconnect();
-          return existingSlot;
-        }
-      }
-    }
-
     const hid = new DualsenseHID(provider);
     const controller = new Dualsense({ hid });
     const index = this.slots.length;
 
-    const slot: ControllerSlot = { controller, serial, path, index };
+    const slot: ControllerSlot = {
+      controller,
+      serial,
+      path,
+      index,
+      // Hide from public state until firmware info has been read and any
+      // identity-based merge has had a chance to run.
+      provisional: true,
+    };
     this.slots.push(slot);
 
     if (serial) {
@@ -320,9 +382,154 @@ export class DualsenseManager extends Input<DualsenseManagerState> {
       this.updateState();
     });
 
+    // Hook firmware-info readiness so we can perform identity-based slot
+    // matching once the controller's hardware identity is known. This is
+    // far more reliable than node-hid's serial number, which is
+    // frequently missing or wrong (especially over Bluetooth on Linux).
+    if (!slot.readyHooked) {
+      slot.readyHooked = true;
+      hid.onReady(() => this.handleSlotReady(slot));
+    }
+
     this.updateState();
 
     return slot;
+  }
+
+  /**
+   * Called when a slot's HID layer has finished reading firmware/factory info.
+   * If the resolved identity matches a *different* (disconnected) slot, the
+   * underlying device is transplanted into that slot's existing provider so
+   * the consumer's Dualsense reference is preserved across reconnect.
+   */
+  private handleSlotReady(slot: ControllerSlot): void {
+    const identity = slot.controller.hid.identity;
+
+    // No identity at all (firmware read failed completely after retries) —
+    // promote the slot anyway so the consumer can still use it. We just
+    // won't be able to merge it on reconnect.
+    if (!identity) {
+      this.promoteSlot(slot);
+      return;
+    }
+
+    const existingIndex = this.identityToSlot.get(identity);
+
+    // First time we've seen this identity — claim it for this slot.
+    if (existingIndex === undefined) {
+      slot.identity = identity;
+      this.identityToSlot.set(identity, slot.index);
+      this.promoteSlot(slot);
+      return;
+    }
+
+    // We already have a slot for this identity — make sure it's not just us.
+    if (existingIndex === slot.index) {
+      this.promoteSlot(slot);
+      return;
+    }
+
+    const existingSlot = this.slots[existingIndex] as
+      | ControllerSlot
+      | undefined;
+    if (!existingSlot) {
+      // Stale mapping — overwrite.
+      slot.identity = identity;
+      this.identityToSlot.set(identity, slot.index);
+      this.promoteSlot(slot);
+      return;
+    }
+
+    // If the existing slot is currently connected, both slots map to the
+    // same hardware (shouldn't normally happen). Prefer the older slot
+    // and drop the new one without ever publishing it.
+    if (existingSlot.controller.connection.active) {
+      this.dropSlot(slot);
+      return;
+    }
+
+    // Existing slot is disconnected — transplant the new device into it.
+    // The new (provisional) slot is dropped before any state is published,
+    // so the consumer only ever sees the original slot reconnect in place.
+    this.transplant(slot, existingSlot);
+  }
+
+  /** Mark a slot as visible to consumers and publish state */
+  private promoteSlot(slot: ControllerSlot): void {
+    if (!slot.provisional) return;
+    slot.provisional = false;
+    this.updateState();
+  }
+
+  /**
+   * Move the device handle from `from` into `into`'s existing provider so
+   * the existing Dualsense instance reconnects in place. Then remove `from`.
+   */
+  private transplant(from: ControllerSlot, into: ControllerSlot): void {
+    const fromProvider = from.controller.hid.provider;
+    const intoProvider = into.controller.hid.provider;
+
+    if (
+      fromProvider instanceof WebHIDProvider &&
+      intoProvider instanceof WebHIDProvider &&
+      fromProvider.device
+    ) {
+      // Move the open HIDDevice handle from the source provider to the
+      // destination. We can't close + reopen here — that would race with
+      // the destination's attach() call. Instead we abandon the source
+      // provider in place (its slot is about to be dropped) and let the
+      // destination take over the same handle. The source's input listener
+      // will be GC'd along with the source provider once nothing else
+      // references the dropped slot's Dualsense.
+      const device = fromProvider.device;
+      fromProvider.device = undefined;
+      if (fromProvider.deviceId) {
+        HIDProvider.claimedDevices.delete(fromProvider.deviceId);
+        fromProvider.deviceId = undefined;
+      }
+      intoProvider.replaceDevice(device);
+    } else if (
+      fromProvider instanceof NodeHIDProvider &&
+      intoProvider instanceof NodeHIDProvider
+    ) {
+      // node-hid HID handles can't be moved between providers, so we close
+      // the source (releasing its path claim) and re-open the same path on
+      // the destination provider — preserving the existing Dualsense
+      // instance and its subscribers.
+      const newPath = from.path;
+      const newSerial = from.serial;
+      fromProvider.disconnect();
+      intoProvider.targetPath = newPath;
+      intoProvider.targetSerial = newSerial;
+      into.path = newPath;
+      into.serial = newSerial;
+      void Promise.resolve(intoProvider.connect()).catch(() => {
+        /* errors surface via provider.onError */
+      });
+    }
+
+    this.dropSlot(from);
+  }
+
+  /** Remove a slot without firing the player-LED reshuffle */
+  private dropSlot(slot: ControllerSlot): void {
+    const idx = this.slots.indexOf(slot);
+    if (idx === -1) return;
+
+    if (slot.identity) this.identityToSlot.delete(slot.identity);
+    if (slot.serial) this.serialToSlot.delete(slot.serial);
+
+    this.slots.splice(idx, 1);
+
+    // Re-index the trailing slots
+    for (let i = idx; i < this.slots.length; i++) {
+      const s = this.slots[i];
+      s.index = i;
+      if (s.identity) this.identityToSlot.set(s.identity, i);
+      if (s.serial) this.serialToSlot.set(s.serial, i);
+    }
+
+    this.updateState();
   }
 
   // --- Node.js discovery ---
@@ -345,33 +552,27 @@ export class DualsenseManager extends Input<DualsenseManagerState> {
     this.discoveryTimer = setInterval(() => void poll(), intervalMs);
   }
 
-  /** Handle a newly discovered device from enumeration */
+  /**
+   * Handle a newly discovered device from enumeration. Opens the device on
+   * a fresh provider, which adds it to `claimedDevices` so subsequent polls
+   * skip it. Identity matching (and any merge into a disconnected slot)
+   * happens later, once firmware info has been read.
+   */
   private processDiscoveredDevice(device: DualsenseDeviceInfo): void {
     if (HIDProvider.claimedDevices.has(device.path)) return;
 
-    // Check if this serial matches a disconnected slot
-    if (device.serialNumber !== undefined) {
-      const existingSlotIndex = this.serialToSlot.get(device.serialNumber);
-      if (existingSlotIndex !== undefined) {
-        const slot = this.slots[existingSlotIndex];
-        if (!slot.controller.connection.active) {
-          // Update the existing provider to reconnect via this path
-          const provider = slot.controller.hid.provider as NodeHIDProvider;
-          provider.targetPath = device.path;
-          provider.targetSerial = device.serialNumber;
-          slot.path = device.path;
-          // The Dualsense's internal 200ms loop will call provider.connect()
-          return;
-        }
-      }
-    }
-
-    // New device: create a provider and slot
     const provider = new NodeHIDProvider({
       devicePath: device.path,
       serialNumber: device.serialNumber,
     });
     this.createSlot(provider, device.serialNumber, device.path);
+    // Drive the connection. The Dualsense instance no longer polls in
+    // managed mode, so the manager owns this. claimedDevices is added
+    // synchronously inside connect() on success, preventing duplicate
+    // discovery on the next poll tick.
+    void Promise.resolve(provider.connect()).catch(() => {
+      /* errors surface via provider.onError */
+    });
   }
 
   // --- WebHID discovery ---

--- a/webhid_example/src/App.tsx
+++ b/webhid_example/src/App.tsx
@@ -396,6 +396,7 @@ function useManagerState() {
   const [activeCount, setActiveCount] = React.useState(
     manager?.state.active ?? 0,
   );
+  const [pending, setPending] = React.useState(manager?.pending ?? false);
 
   React.useEffect(() => {
     const m = manager;
@@ -403,17 +404,18 @@ function useManagerState() {
     const update = () => {
       setControllers([...m.controllers]);
       setActiveCount(m.state.active);
+      setPending(m.pending);
     };
     m.on("change", update);
     const interval = setInterval(update, 500);
     return () => clearInterval(interval);
   }, []);
 
-  return { controllers, activeCount };
+  return { controllers, activeCount, pending };
 }
 
 export const App = () => {
-  const { controllers } = useManagerState();
+  const { controllers, pending } = useManagerState();
   const [selectedIndex, setSelectedIndex] = React.useState(0);
   const [panel, setPanel] = React.useState<"triggers" | "debug" | null>(null);
   const [scale, setScale] = React.useState(1);

--- a/webhid_example/src/App.tsx
+++ b/webhid_example/src/App.tsx
@@ -10,6 +10,7 @@ import {
   MuteLedControls,
 } from "./hud";
 import { AudioIndicator } from "./hud/AudioIndicator";
+import { ColorIndicator } from "./hud/ColorIndicator";
 import { Debugger } from "./hud/Debugger";
 import { RightStick } from "./hud/RightStick";
 import { LeftShoulder, RightShoulder } from "./hud/ShoulderVisualization";
@@ -507,6 +508,7 @@ export const App = () => {
             <BatteryIndicator />
             <MuteLedControls />
             <AudioIndicator />
+            <ColorIndicator />
             <LightbarFadeButtons />
             {connected && (
               <>

--- a/webhid_example/src/App.tsx
+++ b/webhid_example/src/App.tsx
@@ -415,7 +415,7 @@ function useManagerState() {
 }
 
 export const App = () => {
-  const { controllers, pending } = useManagerState();
+  const { controllers } = useManagerState();
   const [selectedIndex, setSelectedIndex] = React.useState(0);
   const [panel, setPanel] = React.useState<"triggers" | "debug" | null>(null);
   const [scale, setScale] = React.useState(1);

--- a/webhid_example/src/hud/AudioIndicator.tsx
+++ b/webhid_example/src/hud/AudioIndicator.tsx
@@ -10,11 +10,13 @@ export const AudioIndicator = () => {
   const [connected, setConnected] = useState(controller.connection.state);
 
   useEffect(() => {
+    setMic(controller.microphone.state);
+    setHeadphone(controller.headphone.state);
+    setConnected(controller.connection.state);
     controller.microphone.on("change", ({ state }) => setMic(state));
     controller.headphone.on("change", ({ state }) => setHeadphone(state));
     controller.connection.on("change", ({ state }) => setConnected(state));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [controller]);
 
   if (!connected) return null;
   if (!mic && !headphone) return null;

--- a/webhid_example/src/hud/BatteryIndicator.tsx
+++ b/webhid_example/src/hud/BatteryIndicator.tsx
@@ -47,11 +47,13 @@ export const BatteryIndicator = () => {
   const [connected, setConnected] = useState(controller.connection.state);
 
   useEffect(() => {
+    setLevel(controller.battery.level.state);
+    setStatus(controller.battery.status.state);
+    setConnected(controller.connection.state);
     controller.battery.level.on("change", ({ state }) => setLevel(state));
     controller.battery.status.on("change", ({ state }) => setStatus(state));
     controller.connection.on("change", ({ state }) => setConnected(state));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [controller]);
 
   if (!connected) return null;
 

--- a/webhid_example/src/hud/ColorIndicator.tsx
+++ b/webhid_example/src/hud/ColorIndicator.tsx
@@ -1,0 +1,71 @@
+import { useContext, useEffect, useState } from "react";
+import { Tag } from "@blueprintjs/core";
+import styled from "styled-components";
+import type { FactoryInfo } from "dualsense-ts";
+
+import { ControllerContext } from "../Controller";
+
+/** Approximate CSS colors for known DualSense body colors */
+const colorCss: Record<string, string> = {
+  "00": "#e8e8e8",
+  "01": "#1a1a2e",
+  "02": "#c8102e",
+  "03": "#f2a6c0",
+  "04": "#6b3fa0",
+  "05": "#5b9bd5",
+  "06": "#8a9a7b",
+  "07": "#9b2335",
+  "08": "#c0c0c0",
+  "09": "#1e3a5f",
+  "10": "#2db5a0",
+  "11": "#3d4f7c",
+  "12": "#e8dfd0",
+  "30": "#4a4a4a",
+};
+
+const ColorDot = styled.span<{ $color: string }>`
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: ${(p) => p.$color};
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  flex-shrink: 0;
+`;
+
+export const ColorIndicator = () => {
+  const controller = useContext(ControllerContext);
+  const [factory, setFactory] = useState<FactoryInfo | undefined>(
+    controller.factoryInfo
+  );
+  const [connected, setConnected] = useState(controller.connection.state);
+
+  useEffect(() => {
+    controller.on("change", (c) => {
+      if (!factory && c.factoryInfo) {
+        setFactory(c.factoryInfo);
+      }
+    });
+    controller.connection.on("change", ({ state }) => {
+      setConnected(state);
+      if (!state) setFactory(undefined);
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  if (!connected || !factory) return null;
+
+  const css = colorCss[factory.colorCode];
+  const label = factory.colorName ?? factory.colorCode;
+
+  return (
+    <Tag
+      minimal={true}
+      intent="none"
+      icon={css ? <ColorDot $color={css} /> : undefined}
+      title={`Controller color: ${label}${factory.boardRevision ? ` (${factory.boardRevision})` : ""}`}
+    >
+      {label}
+    </Tag>
+  );
+};

--- a/webhid_example/src/hud/ColorIndicator.tsx
+++ b/webhid_example/src/hud/ColorIndicator.tsx
@@ -41,8 +41,10 @@ export const ColorIndicator = () => {
   const [connected, setConnected] = useState(controller.connection.state);
 
   useEffect(() => {
+    setConnected(controller.connection.state);
+    setFactory(controller.factoryInfo);
     controller.on("change", (c) => {
-      if (!factory && c.factoryInfo) {
+      if (c.factoryInfo) {
         setFactory(c.factoryInfo);
       }
     });
@@ -50,8 +52,7 @@ export const ColorIndicator = () => {
       setConnected(state);
       if (!state) setFactory(undefined);
     });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [controller]);
 
   if (!connected || !factory) return null;
 

--- a/webhid_example/src/hud/ControllerConnection.tsx
+++ b/webhid_example/src/hud/ControllerConnection.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState, useContext } from "react";
-import { Button as BlueprintButton, Tag } from "@blueprintjs/core";
+import { Button as BlueprintButton, Tag, Spinner } from "@blueprintjs/core";
 import styled, { keyframes } from "styled-components";
 
-import { ControllerContext, requestPermission } from "../Controller";
+import { ControllerContext, ManagerContext, requestPermission } from "../Controller";
 
 const StatusContainer = styled.div`
   display: flex;
@@ -21,14 +21,41 @@ const PulsingButton = styled(BlueprintButton)`
 
 export const ControllerConnection = () => {
   const controller = useContext(ControllerContext);
+  const manager = useContext(ManagerContext);
   const [connected, setConnected] = useState(controller.connection.state);
+  const [pending, setPending] = useState(manager?.pending ?? false);
 
   useEffect(() => {
+    // Sync immediately — the controller may already be connected when the
+    // context switches (e.g. after a provisional slot promotes).
+    setConnected(controller.connection.state);
     const handler = ({ state }: { state: boolean }) => setConnected(state);
     controller.connection.on("change", handler);
   }, [controller]);
 
+  // The manager doesn't expose a typed event for `pending` flips, so we
+  // poll its state alongside the existing 500ms App-level poll.
+  useEffect(() => {
+    if (!manager) return;
+    const tick = () => setPending(manager.pending);
+    tick();
+    const interval = setInterval(tick, 250);
+    return () => clearInterval(interval);
+  }, [manager]);
+
   if (!connected) {
+    // A controller has been opened but firmware/identity is still loading —
+    // show a spinner instead of the "Connect" button so we don't ask the
+    // user to take action on a controller that is already wired up.
+    if (pending) {
+      return (
+        <StatusContainer>
+          <Tag minimal={true} intent="warning" icon={<Spinner size={12} />}>
+            Connecting...
+          </Tag>
+        </StatusContainer>
+      );
+    }
     return (
       <StatusContainer>
         <PulsingButton

--- a/webhid_example/src/hud/Debugger.tsx
+++ b/webhid_example/src/hud/Debugger.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 import { Card, Switch } from "@blueprintjs/core";
-import { DualsenseHIDState } from "dualsense-ts";
+import { DualsenseHIDState, FirmwareInfo, FactoryInfo, formatFirmwareVersion } from "dualsense-ts";
 
 import { ControllerContext } from "../Controller";
 import { TriggerEffectControls } from "./TriggerEffectControls";
@@ -27,10 +27,22 @@ export const Debugger = ({ panel }: DebuggerProps) => {
 
   const [showReport, setShowReport] = React.useState<boolean>(false);
   const [showState, setShowState] = React.useState<boolean>(false);
+  const [firmware, setFirmware] = React.useState<FirmwareInfo | undefined>(
+    controller.firmwareInfo
+  );
+  const [factory, setFactory] = React.useState<FactoryInfo | undefined>(
+    controller.factoryInfo
+  );
 
   React.useEffect(() => {
     controller.on("change", (controller) => {
       setDebugState(controller.hid.state);
+      if (!firmware && controller.firmwareInfo) {
+        setFirmware(controller.firmwareInfo);
+      }
+      if (!factory && controller.factoryInfo) {
+        setFactory(controller.factoryInfo);
+      }
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -54,6 +66,24 @@ export const Debugger = ({ panel }: DebuggerProps) => {
 
   return (
     <>
+      {firmware && (
+        <Card compact={true}>
+          <p style={{ fontSize: 12, opacity: 0.7, margin: 0 }}>
+            Firmware: v{formatFirmwareVersion(firmware.mainFirmwareVersion)}
+            {" · "}HW: {firmware.hardwareInfo}
+            {" · "}DSP: {firmware.dspFirmwareVersion}
+            {" · "}SBL: v{formatFirmwareVersion(firmware.sblFirmwareVersion)}
+            {" · "}Built: {firmware.buildDate} {firmware.buildTime}
+          </p>
+          {factory && (
+            <p style={{ fontSize: 12, opacity: 0.7, margin: "4px 0 0" }}>
+              Color: {factory.colorName ?? factory.colorCode}
+              {" · "}{factory.boardRevision ?? "Unknown board"}
+              {" · "}Serial: {factory.serialNumber}
+            </p>
+          )}
+        </Card>
+      )}
       <Card compact={true}>
         <Switch
           label="Input State"

--- a/webhid_example/src/hud/LightbarFadeButtons.tsx
+++ b/webhid_example/src/hud/LightbarFadeButtons.tsx
@@ -40,9 +40,9 @@ export const LightbarFadeButtons = () => {
   const [connected, setConnected] = React.useState(controller.connection.state);
 
   React.useEffect(() => {
+    setConnected(controller.connection.state);
     controller.connection.on("change", ({ state }) => setConnected(state));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [controller]);
 
   if (!connected) return null;
 

--- a/webhid_example/src/hud/MuteLedControls.tsx
+++ b/webhid_example/src/hud/MuteLedControls.tsx
@@ -9,10 +9,11 @@ export const MuteLedControls = () => {
   const [connected, setConnected] = useState(controller.connection.state);
 
   useEffect(() => {
+    setLedOn(controller.mute.status.state);
+    setConnected(controller.connection.state);
     controller.mute.status.on("change", ({ state }) => setLedOn(state));
     controller.connection.on("change", ({ state }) => setConnected(state));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [controller]);
 
   if (!connected) return null;
 

--- a/webhid_example/src/hud/index.tsx
+++ b/webhid_example/src/hud/index.tsx
@@ -5,6 +5,7 @@
 export * from "./AudioIndicator";
 export * from "./BatteryIndicator";
 export * from "./BumperVisualization";
+export * from "./ColorIndicator";
 export * from "./ControllerConnection";
 export * from "./Debugger";
 export * from "./DpadVisualization";


### PR DESCRIPTION
This PR exposes interfaces for accessing a controller's firmware and factory details. This includes serial and model numbers, software and hardware revisions, the color of the controller, and more.

Many thanks to [Daidr's dualsense-tester](https://github.com/daidr/dualsense-tester) for the WebHID reference implementation.

The functionality does not work in Linux over bluetooth at the moment. I'll be exploring options to support this.

The change also improves the ability of the DualsenseManager to link controllers to their player slots during reconnects. The devices are now identified by their MAC address in both bluetooth and USB modes, so slot mapping is accurate even when connection type changes.