### PR TITLE
[MINOR] Mute LED override support

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ Effect names are based on [Nielk1's DualSense trigger effect documentation](http
 
 #### Lights
 
-You can control the controller's lightbar as well as the player indicator LEDs:
+You can control the controller's lightbar as well as the player indicator and mute LEDs:
 
 ```typescript
 import { PlayerID, Brightness } from "dualsense-ts";
@@ -299,15 +299,17 @@ controller.playerLeds.setLed(4, true);
 controller.playerLeds.clear(); // All off
 controller.playerLeds.setBrightness(Brightness.Medium); // High, Medium, or Low
 
-// Mute LED — read-only, reflects controller firmware state
-controller.mute.status.on("change", ({ state }) => {
-  console.log(`Mute: ${state ? "muted" : "unmuted"}`);
-});
+// Override the mute LED with a software-controlled mode
+import { MuteLedMode } from "dualsense-ts";
+controller.mute.setLed(MuteLedMode.On); // Solid on
+controller.mute.setLed(MuteLedMode.Pulse); // Slow pulse
+controller.mute.setLed(MuteLedMode.Off); // Force off
+controller.mute.resetLed(); // Return control to firmware
 ```
 
 The `{r, g, b}` format is compatible with popular color libraries. Pass the output of `colord().toRgb()`, `tinycolor().toRgb()`, or `Color().object()` straight to `lightbar.set()`.
 
-The mute LED cannot be controlled (the firmware toggles it on and off with the button) but you can read its current state. `controller.mute` allows you to read the button like a normal input, while `controller.mute.status` is a toggle input tied to the LED's state.
+By default the mute LED is managed by the controller firmware (toggled by the physical button). Use `setLed()` to override with a specific mode, and `resetLed()` to hand control back. A physical button press will also return the LED to firmware control.
 
 #### Audio Peripherals
 
@@ -324,7 +326,15 @@ controller.microphone.on("change", ({ state }) => {
 
 controller.headphone.state; // true when headphones are plugged in
 controller.microphone.state; // true when a microphone is available
+
+// `mute.status` is true when the user has muted the microphone
+// Usually it's tied to the LED state, unless you've overridden the LED
+controller.mute.status.on("change", ({ state }) => {
+  console.log(`Mute: ${state ? "muted" : "unmuted"}`);
+});
 ```
+
+Even though you can override the mute LED's state, you can't forcibly unmute the controller.
 
 #### Color and Serial Number
 
@@ -473,7 +483,7 @@ for (const controller of manager) {
 
 ### Player LEDs
 
-The manager auto-assigns player LED patterns as controllers connect. The first four match the PS5 console convention; slots 5–31 use the remaining 5-bit LED combinations.
+The manager auto-assigns player LED patterns as controllers connect. The first four match the PS5 console convention; slots 5-31 use the remaining 5-bit LED combinations.
 
 ```typescript
 import { DualsenseManager, PlayerID, Brightness } from "dualsense-ts";

--- a/src/dualsense.ts
+++ b/src/dualsense.ts
@@ -27,6 +27,7 @@ import {
   FactoryInfo,
   DualsenseColor,
   DualsenseColorMap,
+  MuteLedMode,
 } from "./hid";
 import { Intensity } from "./math";
 
@@ -267,6 +268,7 @@ export class Dualsense extends Input<Dualsense> {
     const triggerFeedbackMemo = { left: "", right: "" };
     const lightbarMemo = { key: "" };
     const playerLedsMemo = { key: "" };
+    const muteLedMemo: { mode: MuteLedMode | undefined } = { mode: undefined };
 
     // Mirror transport-level connect/disconnect into the connection Momentary,
     // and invalidate output memos on rising-edge connect so the output loop
@@ -278,6 +280,7 @@ export class Dualsense extends Input<Dualsense> {
         triggerFeedbackMemo.right = "";
         lightbarMemo.key = "";
         playerLedsMemo.key = "";
+        muteLedMemo.mode = undefined;
       }
     });
     // Seed the initial state in case the provider was already attached.
@@ -358,6 +361,14 @@ export class Dualsense extends Input<Dualsense> {
           this.playerLeds.brightness,
         );
         playerLedsMemo.key = playerLedsKey;
+      }
+
+      const muteLedMode = this.mute.ledMode;
+      if (muteLedMode !== muteLedMemo.mode) {
+        if (muteLedMode !== undefined) {
+          this.hid.setMicrophoneLED(muteLedMode);
+        }
+        muteLedMemo.mode = muteLedMode;
       }
     }, 1000 / 30);
   }

--- a/src/elements/mute.ts
+++ b/src/elements/mute.ts
@@ -1,6 +1,20 @@
 import { Momentary } from "./momentary";
+import { MuteLedMode } from "../hid/command";
 
 export class Mute extends Momentary {
   /** Whether the mute indicator LED is currently lit (managed by controller firmware) */
   public readonly status = new Momentary({ icon: "🔇", name: "MuteStatus" });
+
+  /** Current software-controlled LED mode, or undefined if firmware-managed */
+  public ledMode?: MuteLedMode;
+
+  /** Set the mute LED mode. Overrides the firmware-managed state. */
+  public setLed(mode: MuteLedMode): void {
+    this.ledMode = mode;
+  }
+
+  /** Release software control, returning the LED to firmware management */
+  public resetLed(): void {
+    this.ledMode = undefined;
+  }
 }

--- a/src/hid/command.ts
+++ b/src/hid/command.ts
@@ -11,6 +11,12 @@ export enum PulseOptions {
   FadeOut = 0x2,
 }
 
+export enum MuteLedMode {
+  Off = 0,
+  On = 1,
+  Pulse = 2,
+}
+
 export enum Brightness {
   High = 0x0,
   Medium = 0x1,

--- a/src/hid/dualsense_hid.ts
+++ b/src/hid/dualsense_hid.ts
@@ -1,4 +1,4 @@
-import { CommandScopeA, CommandScopeB, LedOptions, PulseOptions, Brightness } from "./command";
+import { CommandScopeA, CommandScopeB, LedOptions, PulseOptions, Brightness, MuteLedMode } from "./command";
 import {
   HIDProvider,
   DualsenseHIDState,
@@ -404,11 +404,11 @@ export class DualsenseHID {
     });
   }
 
-  /** Set microphone LED on or off */
-  public setMicrophoneLED(on: boolean): void {
+  /** Set microphone mute LED mode */
+  public setMicrophoneLED(mode: MuteLedMode): void {
     this.pendingCommands.push({
       scope: { index: SCOPE_B, value: CommandScopeB.MicrophoneLED },
-      values: [{ index: 9, value: on ? 1 : 0 }],
+      values: [{ index: 9, value: mode }],
     });
   }
 

--- a/webhid_example/src/hud/UtilityButtons.tsx
+++ b/webhid_example/src/hud/UtilityButtons.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 import { Illustration, Shape, Ellipse } from "react-zdog";
+import { MuteLedMode } from "dualsense-ts";
 
 import { RenderedElement } from "./RenderedElement";
 import { ControllerContext } from "../Controller";
@@ -194,21 +195,45 @@ export const MuteButton = () => {
   const controller = React.useContext(ControllerContext);
   const [pressed, setPressed] = React.useState(controller.mute.state);
   const [muted, setMuted] = React.useState(controller.mute.status.state);
+  const [pulsing, setPulsing] = React.useState(false);
+  const pulsingRef = React.useRef(pulsing);
+  pulsingRef.current = pulsing;
   React.useEffect(() => {
     controller.mute.on("change", ({ state }) => setPressed(state));
-    controller.mute.status.on("change", ({ state }) => setMuted(state));
+    controller.mute.status.on("change", ({ state }) => {
+      setMuted(state);
+      if (pulsingRef.current) {
+        // Match LED to new mute state, replacing our pulse override
+        controller.mute.setLed(state ? MuteLedMode.On : MuteLedMode.Off);
+        setPulsing(false);
+      }
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const color = muted ? ACTIVE : pressed ? ACTIVE : INACTIVE;
+  const handleClick = () => {
+    if (pulsing) {
+      // Match LED to current mute state, replacing our pulse override
+      controller.mute.setLed(
+        controller.mute.status.state ? MuteLedMode.On : MuteLedMode.Off,
+      );
+      setPulsing(false);
+    } else {
+      controller.mute.setLed(MuteLedMode.Pulse);
+      setPulsing(true);
+    }
+  };
+
+  const color = muted || pulsing ? ACTIVE : pressed ? ACTIVE : INACTIVE;
   const hw = PILL_WIDTH / 2;
   const hh = PILL_HEIGHT / 2;
   const r = hh;
   return (
-    <Container>
+    <Container onClick={handleClick} style={{ cursor: "pointer" }}>
       <RenderedElement
         width={(PILL_WIDTH + 2) * ZOOM}
         height={(PILL_HEIGHT + 2) * ZOOM}
+        style={{ pointerEvents: "none" }}
       >
         <Illustration element="svg" zoom={ZOOM}>
           <Shape rotate={{ x: TILT }} stroke={0}>
@@ -246,14 +271,14 @@ export const MuteButton = () => {
                 ]}
                 stroke={0.15}
                 color={color}
-                fill={muted}
+                fill={muted || pulsing}
                 closed={true}
               />
             </Shape>
           </Shape>
         </Illustration>
       </RenderedElement>
-      <VisLabel>{muted ? "Muted" : "Mute"}</VisLabel>
+      <VisLabel>{muted ? (pulsing ? "Pulsing" : "Muted") : "Mute"}</VisLabel>
     </Container>
   );
 };


### PR DESCRIPTION
Adds a new API for overriding the state of the mute LED. The LED is also controlled in firmware and there doesn't appear to be any direct way to check the current LED state (only the muted/unmuted state), so a best effort is made to keep the state synchronized when you return control to firmware.