### PR TITLE
Improve handling for unsupported browsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `dualsense-ts` are documented here. This project uses [Semantic Versioning](https://semver.org/).
 
+## [6.9.10] - 2026-04-13
+
+### Fixed
+
+- Fix for renderingthe docs pages in unsupported browsers
+
 ## [6.9.5] - 2026-04-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ All notable changes to `dualsense-ts` are documented here. This project uses [Se
 
 ### Fixed
 
-- Fix for renderingthe docs pages in unsupported browsers
+- Fix for rendering docs pages in unsupported browsers
+
+### Added
+
+- `null_hid_provider` to simplify compatibility for incompatible browser environments
 
 ## [6.9.5] - 2026-04-13
 

--- a/documentation_app/src/pages/ReactPage.tsx
+++ b/documentation_app/src/pages/ReactPage.tsx
@@ -317,6 +317,72 @@ function ConnectButton() {
 }`}
     />
 
+    {/* ── Browser compatibility ────────────────────────────── */}
+
+    <SectionHeading>Browser Compatibility</SectionHeading>
+    <Prose>
+      <p>
+        <a
+          href="https://developer.mozilla.org/en-US/docs/Web/API/WebHID_API#browser_compatibility"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          WebHID
+        </a>{" "}
+        is supported in Chromium-based browsers (Chrome, Edge, Opera) but
+        not in Firefox or Safari. Your app should still render in
+        unsupported browsers — guard the manager and use a headless
+        placeholder so the component tree mounts without errors.
+      </p>
+    </Prose>
+    <CodeBlock
+      code={`// controller.ts
+import { createContext } from "react";
+import { Dualsense, DualsenseManager } from "dualsense-ts";
+
+export const hasWebHID =
+  typeof navigator !== "undefined" && "hid" in navigator;
+
+// Only create a manager in supported browsers
+export const manager: DualsenseManager | null = hasWebHID
+  ? new DualsenseManager()
+  : null;
+
+export const requestPermission: () => void = manager
+  ? manager.getRequest()
+  : () => {};
+
+// Placeholder with { hid: null } — a headless instance that never
+// connects. All inputs return neutral defaults (false, 0, etc.)
+// so components render normally without a real controller.
+export const ControllerContext = createContext<Dualsense>(
+  manager?.get(0) ?? new Dualsense({ hid: null }),
+);`}
+    />
+    <Prose>
+      <p>
+        With this pattern, every <code>useControllerInput</code> hook works
+        in any browser — it just always reads the default state when WebHID
+        is unavailable. Show a compatibility message where appropriate:
+      </p>
+    </Prose>
+    <CodeBlock
+      code={`import { hasWebHID, requestPermission } from "./controller";
+
+function ConnectPrompt() {
+  if (!hasWebHID) {
+    return (
+      <div>
+        WebHID is not supported in this browser.
+        Try Chrome, Edge, or Opera for interactive controller features.
+      </div>
+    );
+  }
+
+  return <button onClick={requestPermission}>Connect Controller</button>;
+}`}
+    />
+
     {/* ── High-frequency inputs ──────────────────────────── */}
 
     <SectionHeading>High-Frequency Inputs</SectionHeading>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dualsense-ts",
   "version": "0.0.0",
-  "description": "A natural interface for your DualSense controller, with Typescript",
+  "description": "The natural interface for your DualSense controller, with Typescript",
   "keywords": [
     "dualsense",
     "typescript",
@@ -14,7 +14,7 @@
     "webhid",
     "node-hid"
   ],
-  "homepage": "https://github.com/nsfm/dualsense-ts",
+  "homepage": "https://nsfm.github.io/dualsense-ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/nsfm/dualsense-ts.git"

--- a/src/dualsense.ts
+++ b/src/dualsense.ts
@@ -20,6 +20,7 @@ import { Input, InputSet, InputParams } from "./input";
 import {
   DualsenseHIDState,
   DualsenseHID,
+  NullHIDProvider,
   PlatformHIDProvider,
   InputId,
   ChargeStatus,
@@ -261,10 +262,16 @@ export class Dualsense extends Input<Dualsense> {
 
     this.connection[InputSet](false);
     // If a HID instance was supplied externally (e.g. by DualsenseManager),
-    // the owner is responsible for driving discovery + reconnection. Otherwise
-    // construct a default platform provider and run our own discovery loop.
-    const externallyManaged = params.hid != null;
-    this.hid = params.hid ?? new DualsenseHID(new PlatformHIDProvider());
+    // the owner is responsible for driving discovery + reconnection.
+    // `hid: null` creates a headless instance with no provider — useful for
+    // placeholder controllers in UIs where WebHID may not be available.
+    // Otherwise, construct a default platform provider and run our own
+    // discovery loop.
+    const externallyManaged = params.hid !== undefined;
+    this.hid =
+      params.hid === null
+        ? new DualsenseHID(new NullHIDProvider())
+        : (params.hid ?? new DualsenseHID(new PlatformHIDProvider()));
     this.hid.register((state: DualsenseHIDState) => {
       this.processHID(state);
     });

--- a/src/hid/index.ts
+++ b/src/hid/index.ts
@@ -12,6 +12,7 @@ export * from "./factory_info";
 export * from "./firmware_info";
 export * from "./hid_provider";
 export * from "./node_hid_provider";
+export * from "./null_hid_provider";
 export * from "./pairing_info";
 export * from "./platform_hid_provider";
 export * from "./web_hid_provider";

--- a/src/hid/null_hid_provider.ts
+++ b/src/hid/null_hid_provider.ts
@@ -1,0 +1,20 @@
+import { HIDProvider, DualsenseHIDState, DefaultDualsenseHIDState } from "./hid_provider";
+
+/**
+ * A no-op HID provider that never connects. Used for placeholder Dualsense
+ * instances in environments where no HID backend is available (e.g. browsers
+ * without WebHID support).
+ */
+export class NullHIDProvider extends HIDProvider {
+  public device = undefined;
+  public wireless = undefined;
+  public buffer = undefined;
+
+  connect(): void {}
+  disconnect(): void {}
+  get connected(): boolean { return false; }
+  process(): DualsenseHIDState { return { ...DefaultDualsenseHIDState }; }
+  async write(): Promise<void> {}
+  readFeatureReport(): Promise<Uint8Array> { return Promise.resolve(new Uint8Array(0)); }
+  async sendFeatureReport(): Promise<void> {}
+}


### PR DESCRIPTION
Prevent the docs app from crashing in unsupported browsers, and add extra utilities to make this simpler for downstream consumers.